### PR TITLE
fix: tapButton dubble tab error

### DIFF
--- a/3dollar-in-my-pocket-manager/domains/home/HomeViewController.swift
+++ b/3dollar-in-my-pocket-manager/domains/home/HomeViewController.swift
@@ -68,6 +68,7 @@ final class HomeViewController: BaseViewController, View, HomeCoordinator {
             .disposed(by: self.disposeBag)
         
         self.homeView.salesToggleView.rx.tapButton
+            .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
             .map { Reactor.Action.tapSalesToggle }
             .bind(to: reactor.action)
             .disposed(by: self.disposeBag)


### PR DESCRIPTION
## Overview 👩🏻‍💻
Linked Issue: #1 

## 변경 내용 ⚒️
- 추가/수정한 내용을 적어주세요.
홈 화면에서 오늘의 영업 시작하기 버튼이나 셔터 내리기버튼을 사용자가 500ms안에 연타로 누르면, 버튼이 처음 눌러졌을 때와 500ms안에 눌러진 마지막 버튼만 작동이 되도록 `.Throttle` operator를 이용해서 구현했습니다.

## 질문 🧐
🤚🏻질문 1
[Rx 공문](https://reactivex.io/documentation/operators/debounce.html)을 확인해봤을때 Rx 에서는 Debounce가 쓰이고, RxSwift에서 Debounce와 Throttle가 나뉘어서 사용되는 걸로 생각했습니다.
[Rx 공문](https://reactivex.io/documentation/operators/debounce.html)에는 Debounce와 관련된 내용 밖에 없어서, [RxSwift GitHub](https://github.com/ReactiveX/RxSwift/blob/main/RxSwift/Observables/Throttle.swift)를 통해 Throttle와 관련된 내용을 확인했는데, 이 방법 말고 RxSwift Throttle의 설명이나 마블을 확인할 수 있는 방법이 있는지 궁금합니다. 
(마블은 [RxJS](https://rxmarbles.com/#debounce)을 참고했습니다..)

🤚🏻질문 2
SPM, CocoaPod version이 올라간 것 같은데 down시켜서 PR 날려야 할까요?

🤚🏻질문 3
Project는 따로 태그하지 않나도 되나요 ?
<img width="322" alt="스크린샷 2023-01-04 오후 2 14 42" src="https://user-images.githubusercontent.com/82457928/210488894-59c1b5c1-2f2d-467e-876e-df50d6b69101.png">

🤚🏻질문 4
Branch 이름이 SERVICE-1 이렇게 따는 게 맞나요 ? Wiki에서 본대로 하긴 했는데 SERVICE가 앞에 붙는 게 다소 어색하게 느껴져서요..! 만약 맞다면, SERVICE을 붙이는 이유가 뭔지 궁금합니다..!

+) Issue를 자세하게 적어주셔서 bug를 빨리 이해했던 것 같습니다🥺 배려 감사합니다 !

## [Reference]
[Rx 공문](https://reactivex.io/documentation/operators/debounce.html)
[RxSwift GitHub](https://github.com/ReactiveX/RxSwift/blob/main/RxSwift/Observables/Throttle.swift)
[RxJS marbles](https://rxmarbles.com/#debounce)
[RxSwift :: 중복 클릭 방지를 위한 Throttle vs Debounce 차이와 개념, 사용법 알아보기 (iOS 개발)](https://opendoorlife.tistory.com/19)
[`Observable`을 `ControlEvent`로 변환하는 방법](https://stackoverflow.com/questions/52992332/how-to-convert-observable-to-controlevent)