### PR TITLE
TH-248 : 카테고리 선택 해제 시, 로직 동작 하지 않는 이슈 수정

### DIFF
--- a/3dollar-in-my-pocket-manager/domains/membership/signup/SignupViewController.swift
+++ b/3dollar-in-my-pocket-manager/domains/membership/signup/SignupViewController.swift
@@ -119,6 +119,11 @@ final class SignupViewController: BaseViewController, View, SignupCoordinator {
             .bind(to: reactor.action)
             .disposed(by: self.disposeBag)
         
+        signupView.categoryCollectionView.categoryCollectionView.rx.itemDeselected
+            .map { Reactor.Action.selectCategory(index: $0.row) }
+            .bind(to: reactor.action)
+            .disposed(by: self.disposeBag)
+        
         self.signupView.signupButton.rx.tap
             .map { Reactor.Action.tapSignup }
             .bind(to: reactor.action)


### PR DESCRIPTION
## Overview 👩🏻‍💻
- [TH-248 : 카테고리 선택 해제 시, 로직 동작 하지 않는 이슈 수정](https://3dollarinmypocket.atlassian.net/browse/TH-248)

## 변경 내용 ⚒️
- 카테고리 선택 해재 시, 이벤트 바인딩
