### PR TITLE
TH-1193 : 자주쓰는 문구 바텀시트 미노출 수정

### DIFF
--- a/3dollar-in-my-pocket-manager/domains/MyStore/Statistics/ReviewDetail/ReviewDetailViewController.swift
+++ b/3dollar-in-my-pocket-manager/domains/MyStore/Statistics/ReviewDetail/ReviewDetailViewController.swift
@@ -27,8 +27,6 @@ final class ReviewDetailViewController: BaseViewController {
     
     
     private let viewModel: ReviewDetailViewModel
-    private var commentPresetBottomSheet: CommentPresetBottomSheet?
-    private var addCommentPresetBottomSheet: AddCommentPresetBottomSheet?
     private var originalBottomInset: CGFloat = 0
     private let tapGesture = UITapGestureRecognizer()
     
@@ -312,30 +310,26 @@ extension ReviewDetailViewController {
     }
     
     private func presentCommentPresetBottomSheet(viewModel: CommentPresetBottomSheetViewModel) {
-        if let addCommentPresetBottomSheet {
-            addCommentPresetBottomSheet.dismiss(animated: true) { [weak self] in
+        if let presentedViewController {
+            presentedViewController.dismiss(animated: true) { [weak self] in
                 let viewController = CommentPresetBottomSheet(viewModel: viewModel)
-                self?.commentPresetBottomSheet = viewController
                 self?.presentPanModal(viewController)
             }
         } else {
             let viewController = CommentPresetBottomSheet(viewModel: viewModel)
-            self.commentPresetBottomSheet = viewController
             presentPanModal(viewController)
         }
     }
-    
+
     private func presentAddCommentBottomSheet(viewModel: AddCommentPresetBottomSheetViewModel) {
-        if let commentPresetBottomSheet {
-            commentPresetBottomSheet.dismiss(animated: true) { [weak self] in
+        if let presentedViewController {
+            presentedViewController.dismiss(animated: true) { [weak self] in
                 let viewController = AddCommentPresetBottomSheet(viewModel: viewModel)
                 self?.presentPanModal(viewController)
-                self?.addCommentPresetBottomSheet = viewController
             }
         } else {
             let viewController = AddCommentPresetBottomSheet(viewModel: viewModel)
             presentPanModal(viewController)
-            self.addCommentPresetBottomSheet = viewController
         }
     }
 }


### PR DESCRIPTION
## 원인 (검증 후 재평가)
자주쓰는 문구/문구 추가 바텀시트를 `ReviewDetailViewController`의 저장 프로퍼티(`commentPresetBottomSheet`, `addCommentPresetBottomSheet`)로 들고 있지만, 시트가 dismiss된 뒤에도 참조를 nil로 초기화하지 않아 stale 참조에 `dismiss(animated:completion:)`을 호출하는 경로가 존재합니다.

**문제 코드:** `ReviewDetailViewController.swift` — `presentCommentPresetBottomSheet(viewModel:)`, `presentAddCommentBottomSheet(viewModel:)` (line 314~340)

**⚠️ 시뮬레이터 검증 결과(iOS 26.2):** detached VC에 대한 dismiss도 completion이 호출되어, **stale 참조 단독으로는 미노출 증상이 재현되지 않았습니다.** TH-1193의 실제 사용자 증상(딤만 표시되고 시트 미노출)의 근본 원인은 PanModal 1.2.7 버그이며 #47에서 수정됩니다. 이 PR은 다음 가치로 유지합니다:
- stale 참조 기반 분기 제거 → 실제 presentation 상태(`presentedViewController`) 기준으로 동작해 UIKit 버전별 dismiss-completion 동작 차이에 의존하지 않음
- 불필요한 저장 프로퍼티 2개 제거로 코드 단순화

## 재현 경로 (TH-1193 원 증상)
1. 리뷰 상세 → "자주 쓰는 문구" 탭
2. 실제: 딤만 깔리고 시트 미노출 (#47에서 수정) / 기대: 시트 노출

## 수정 내용
- `ReviewDetailViewController.swift`: `commentPresetBottomSheet`/`addCommentPresetBottomSheet` 저장 프로퍼티 제거, `presentedViewController` 기준으로 dismiss→present 처리

## Before / After (iOS 26.2 시뮬레이터, mock repository 하네스)

#47(PanModal 패치)과 함께 적용한 상태에서, 문구 추가 시트를 열고 닫는 왕복(과거 stale 참조가 생기는 시나리오) 후 "자주 쓰는 문구" 재진입이 정상 동작함을 확인했습니다:

| 시나리오 | 결과 (이 PR + #47) |
| --- | --- |
| 문구 시트 열기 → 문구 추가 열기 → 닫기 → 문구 시트 닫기 → **재탭** | <img src="https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-manager-ios/releases/download/verification-assets/TH-1193-after-reopen.png" width="300"> |

- 재탭 시 자주 쓰는 문구 시트 정상 재노출 (회귀 없음)
- 스크린샷 원본: verification-assets 릴리스(Pre-release) / 하네스 코드는 커밋되지 않음

## 검증
- ✅ Debug 빌드 성공 (3dollar-in-my-pocket-manager-dev)
- ✅ SwiftLint: 수정 파일에 error 없음
- ✅ #47과 병합한 빌드에서 자주쓰는 문구/문구 추가/재진입 전체 플로우 정상 동작 확인 (위 표)

## 영향 범위
- 리뷰 상세 화면의 자주쓰는 문구/문구 추가·수정 바텀시트 present 흐름
- **리스크:** 매우 낮음 (동작 동등성 시뮬레이터 확인 완료, 분기 로직 단순화)

## 관련 이슈
- Jira: TH-1193 (사용자 증상의 주 원인 수정은 #47)
