### PR TITLE
TH-1192 : 리뷰 신고/자주쓰는 문구 바텀시트 미노출 수정 (PanModal 패치)

### DIFF
--- a/3dollar-in-my-pocket-manager.xcodeproj/project.pbxproj
+++ b/3dollar-in-my-pocket-manager.xcodeproj/project.pbxproj
@@ -1913,7 +1913,7 @@
 				6EEBC7BD28731F7700CBA0F0 /* XCRemoteSwiftPackageReference "lottie-ios" */,
 				6E2410AF2875550800BADDD5 /* XCRemoteSwiftPackageReference "ReactorKit" */,
 				6E2410B32875553C00BADDD5 /* XCRemoteSwiftPackageReference "RxDataSources" */,
-				6EC8031C2B2C891A00DA4F5E /* XCRemoteSwiftPackageReference "PanModal" */,
+				6EC8031C2B2C891A00DA4F5E /* XCLocalSwiftPackageReference "Frameworks/PanModal" */,
 				6E893CB82C3A65F100357F66 /* XCRemoteSwiftPackageReference "netfox" */,
 				6E8474BA2C54B3200064DE0A /* XCRemoteSwiftPackageReference "CombineCocoa" */,
 				6E6B82B42CF980E300A5BFAC /* XCRemoteSwiftPackageReference "Then" */,
@@ -2651,13 +2651,9 @@
 				version = 2.7.4;
 			};
 		};
-		6EC8031C2B2C891A00DA4F5E /* XCRemoteSwiftPackageReference "PanModal" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/slackhq/PanModal.git";
-			requirement = {
-				kind = exactVersion;
-				version = 1.2.7;
-			};
+		6EC8031C2B2C891A00DA4F5E /* XCLocalSwiftPackageReference "Frameworks/PanModal" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Frameworks/PanModal;
 		};
 		6ED8838827CB395B00278E14 /* XCRemoteSwiftPackageReference "SnapKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -2785,7 +2781,6 @@
 		};
 		6EC8031D2B2C891A00DA4F5E /* PanModal */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 6EC8031C2B2C891A00DA4F5E /* XCRemoteSwiftPackageReference "PanModal" */;
 			productName = PanModal;
 		};
 		6ED8838927CB395B00278E14 /* SnapKit */ = {

--- a/3dollar-in-my-pocket-manager.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/3dollar-in-my-pocket-manager.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,276 +1,267 @@
 {
-  "originHash" : "2b70754e70765d5e08f3b248230831ce6cbec0a12a723e48e0f84a5e523b9635",
-  "pins" : [
+  "originHash": "2b70754e70765d5e08f3b248230831ce6cbec0a12a723e48e0f84a5e523b9635",
+  "pins": [
     {
-      "identity" : "abseil-cpp-binary",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/abseil-cpp-binary.git",
-      "state" : {
-        "revision" : "194a6706acbd25e4ef639bcaddea16e8758a3e27",
-        "version" : "1.2024011602.0"
+      "identity": "abseil-cpp-binary",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/google/abseil-cpp-binary.git",
+      "state": {
+        "revision": "194a6706acbd25e4ef639bcaddea16e8758a3e27",
+        "version": "1.2024011602.0"
       }
     },
     {
-      "identity" : "alamofire",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Alamofire/Alamofire.git",
-      "state" : {
-        "revision" : "513364f870f6bfc468f9d2ff0a95caccc10044c5",
-        "version" : "5.10.2"
+      "identity": "alamofire",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/Alamofire/Alamofire.git",
+      "state": {
+        "revision": "513364f870f6bfc468f9d2ff0a95caccc10044c5",
+        "version": "5.10.2"
       }
     },
     {
-      "identity" : "app-check",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/app-check.git",
-      "state" : {
-        "revision" : "21fe1af9be463a359aaf8d96789ef73fc3760d09",
-        "version" : "11.0.1"
+      "identity": "app-check",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/google/app-check.git",
+      "state": {
+        "revision": "21fe1af9be463a359aaf8d96789ef73fc3760d09",
+        "version": "11.0.1"
       }
     },
     {
-      "identity" : "combinecocoa",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/CombineCommunity/CombineCocoa.git",
-      "state" : {
-        "revision" : "7300c75ff9e072aa7fd0fccefcc88f74aae9bf56",
-        "version" : "0.4.1"
+      "identity": "combinecocoa",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/CombineCommunity/CombineCocoa.git",
+      "state": {
+        "revision": "7300c75ff9e072aa7fd0fccefcc88f74aae9bf56",
+        "version": "0.4.1"
       }
     },
     {
-      "identity" : "down",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/johnxnguyen/Down.git",
-      "state" : {
-        "revision" : "f34b166be1f1db4aa8f573067e901d72f2a6be57",
-        "version" : "0.11.0"
+      "identity": "down",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/johnxnguyen/Down.git",
+      "state": {
+        "revision": "f34b166be1f1db4aa8f573067e901d72f2a6be57",
+        "version": "0.11.0"
       }
     },
     {
-      "identity" : "firebase-ios-sdk",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/firebase-ios-sdk",
-      "state" : {
-        "revision" : "2e02253fd1ce99145bcbf1bb367ccf61bd0ca46b",
-        "version" : "11.6.0"
+      "identity": "firebase-ios-sdk",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/firebase/firebase-ios-sdk",
+      "state": {
+        "revision": "2e02253fd1ce99145bcbf1bb367ccf61bd0ca46b",
+        "version": "11.6.0"
       }
     },
     {
-      "identity" : "googleappmeasurement",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/GoogleAppMeasurement.git",
-      "state" : {
-        "revision" : "4f234bcbdae841d7015258fbbf8e7743a39b8200",
-        "version" : "11.4.0"
+      "identity": "googleappmeasurement",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/google/GoogleAppMeasurement.git",
+      "state": {
+        "revision": "4f234bcbdae841d7015258fbbf8e7743a39b8200",
+        "version": "11.4.0"
       }
     },
     {
-      "identity" : "googledatatransport",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/GoogleDataTransport.git",
-      "state" : {
-        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
-        "version" : "10.1.0"
+      "identity": "googledatatransport",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/google/GoogleDataTransport.git",
+      "state": {
+        "revision": "617af071af9aa1d6a091d59a202910ac482128f9",
+        "version": "10.1.0"
       }
     },
     {
-      "identity" : "googleutilities",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/GoogleUtilities.git",
-      "state" : {
-        "revision" : "53156c7ec267db846e6b64c9f4c4e31ba4cf75eb",
-        "version" : "8.0.2"
+      "identity": "googleutilities",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/google/GoogleUtilities.git",
+      "state": {
+        "revision": "53156c7ec267db846e6b64c9f4c4e31ba4cf75eb",
+        "version": "8.0.2"
       }
     },
     {
-      "identity" : "grpc-binary",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/grpc-binary.git",
-      "state" : {
-        "revision" : "f56d8fc3162de9a498377c7b6cea43431f4f5083",
-        "version" : "1.65.1"
+      "identity": "grpc-binary",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/google/grpc-binary.git",
+      "state": {
+        "revision": "f56d8fc3162de9a498377c7b6cea43431f4f5083",
+        "version": "1.65.1"
       }
     },
     {
-      "identity" : "gtm-session-fetcher",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/gtm-session-fetcher.git",
-      "state" : {
-        "revision" : "a2ab612cb980066ee56d90d60d8462992c07f24b",
-        "version" : "3.5.0"
+      "identity": "gtm-session-fetcher",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/google/gtm-session-fetcher.git",
+      "state": {
+        "revision": "a2ab612cb980066ee56d90d60d8462992c07f24b",
+        "version": "3.5.0"
       }
     },
     {
-      "identity" : "interop-ios-for-google-sdks",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
-      "state" : {
-        "revision" : "2d12673670417654f08f5f90fdd62926dc3a2648",
-        "version" : "100.0.0"
+      "identity": "interop-ios-for-google-sdks",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state": {
+        "revision": "2d12673670417654f08f5f90fdd62926dc3a2648",
+        "version": "100.0.0"
       }
     },
     {
-      "identity" : "kakao-ios-sdk",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/kakao/kakao-ios-sdk",
-      "state" : {
-        "revision" : "ab4309c1950550add307046ad1e08024c7514603",
-        "version" : "2.23.0"
+      "identity": "kakao-ios-sdk",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/kakao/kakao-ios-sdk",
+      "state": {
+        "revision": "ab4309c1950550add307046ad1e08024c7514603",
+        "version": "2.23.0"
       }
     },
     {
-      "identity" : "kingfisher",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/onevcat/Kingfisher.git",
-      "state" : {
-        "revision" : "623e1595526a2034dc49eda264a4d174e90dac64",
-        "version" : "8.1.2"
+      "identity": "kingfisher",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/onevcat/Kingfisher.git",
+      "state": {
+        "revision": "623e1595526a2034dc49eda264a4d174e90dac64",
+        "version": "8.1.2"
       }
     },
     {
-      "identity" : "leveldb",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/leveldb.git",
-      "state" : {
-        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
-        "version" : "1.22.5"
+      "identity": "leveldb",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/firebase/leveldb.git",
+      "state": {
+        "revision": "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version": "1.22.5"
       }
     },
     {
-      "identity" : "lookinserver",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/QMUI/LookinServer",
-      "state" : {
-        "revision" : "e553d1b689d147817dc54ad5c28fcff71e860101",
-        "version" : "1.2.8"
+      "identity": "lookinserver",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/QMUI/LookinServer",
+      "state": {
+        "revision": "e553d1b689d147817dc54ad5c28fcff71e860101",
+        "version": "1.2.8"
       }
     },
     {
-      "identity" : "lottie-ios",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/airbnb/lottie-ios.git",
-      "state" : {
-        "revision" : "fe4c6fe3a0aa66cdeb51d549623c82ca9704b9a5",
-        "version" : "4.5.0"
+      "identity": "lottie-ios",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/airbnb/lottie-ios.git",
+      "state": {
+        "revision": "fe4c6fe3a0aa66cdeb51d549623c82ca9704b9a5",
+        "version": "4.5.0"
       }
     },
     {
-      "identity" : "nanopb",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/nanopb.git",
-      "state" : {
-        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
-        "version" : "2.30910.0"
+      "identity": "nanopb",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/firebase/nanopb.git",
+      "state": {
+        "revision": "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version": "2.30910.0"
       }
     },
     {
-      "identity" : "netfox",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/kasketis/netfox",
-      "state" : {
-        "revision" : "557576032736fd3140422baefb68b8f76c55088f",
-        "version" : "1.21.0"
+      "identity": "netfox",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/kasketis/netfox",
+      "state": {
+        "revision": "557576032736fd3140422baefb68b8f76c55088f",
+        "version": "1.21.0"
       }
     },
     {
-      "identity" : "panmodal",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/slackhq/PanModal.git",
-      "state" : {
-        "revision" : "b012aecb6b67a8e46369227f893c12544846613f",
-        "version" : "1.2.7"
+      "identity": "promises",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/google/promises.git",
+      "state": {
+        "revision": "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version": "2.4.0"
       }
     },
     {
-      "identity" : "promises",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/promises.git",
-      "state" : {
-        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
-        "version" : "2.4.0"
+      "identity": "reactorkit",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/ReactorKit/ReactorKit.git",
+      "state": {
+        "revision": "8fa33f09c6f6621a2aa536d739956d53b84dd139",
+        "version": "3.2.0"
       }
     },
     {
-      "identity" : "reactorkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ReactorKit/ReactorKit.git",
-      "state" : {
-        "revision" : "8fa33f09c6f6621a2aa536d739956d53b84dd139",
-        "version" : "3.2.0"
+      "identity": "rxdatasources",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/RxSwiftCommunity/RxDataSources.git",
+      "state": {
+        "revision": "90c29b48b628479097fe775ed1966d75ac374518",
+        "version": "5.0.2"
       }
     },
     {
-      "identity" : "rxdatasources",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/RxSwiftCommunity/RxDataSources.git",
-      "state" : {
-        "revision" : "90c29b48b628479097fe775ed1966d75ac374518",
-        "version" : "5.0.2"
+      "identity": "rxswift",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/ReactiveX/RxSwift.git",
+      "state": {
+        "revision": "b06a8c8596e4c3e8e7788e08e720e3248563ce6a",
+        "version": "6.7.1"
       }
     },
     {
-      "identity" : "rxswift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ReactiveX/RxSwift.git",
-      "state" : {
-        "revision" : "b06a8c8596e4c3e8e7788e08e720e3248563ce6a",
-        "version" : "6.7.1"
+      "identity": "snapkit",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/SnapKit/SnapKit.git",
+      "state": {
+        "revision": "2842e6e84e82eb9a8dac0100ca90d9444b0307f4",
+        "version": "5.7.1"
       }
     },
     {
-      "identity" : "snapkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SnapKit/SnapKit.git",
-      "state" : {
-        "revision" : "2842e6e84e82eb9a8dac0100ca90d9444b0307f4",
-        "version" : "5.7.1"
+      "identity": "sppermissions",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/ivanvorobei/SPPermissions",
+      "state": {
+        "revision": "5e5935998cf9c44033e429c3b7d1dd176a1f55ad",
+        "version": "11.1.0"
       }
     },
     {
-      "identity" : "sppermissions",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ivanvorobei/SPPermissions",
-      "state" : {
-        "revision" : "5e5935998cf9c44033e429c3b7d1dd176a1f55ad",
-        "version" : "11.1.0"
+      "identity": "swift-protobuf",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-protobuf.git",
+      "state": {
+        "revision": "ebc7251dd5b37f627c93698e4374084d98409633",
+        "version": "1.28.2"
       }
     },
     {
-      "identity" : "swift-protobuf",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-protobuf.git",
-      "state" : {
-        "revision" : "ebc7251dd5b37f627c93698e4374084d98409633",
-        "version" : "1.28.2"
+      "identity": "then",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/devxoul/Then",
+      "state": {
+        "revision": "d41ef523faef0f911369f79c0b96815d9dbb6d7a",
+        "version": "3.0.0"
       }
     },
     {
-      "identity" : "then",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/devxoul/Then",
-      "state" : {
-        "revision" : "d41ef523faef0f911369f79c0b96815d9dbb6d7a",
-        "version" : "3.0.0"
+      "identity": "tocropviewcontroller",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/TimOliver/TOCropViewController.git",
+      "state": {
+        "revision": "a634cb7cdfd580006e79a6e74e64417fe9e9783b",
+        "version": "2.7.4"
       }
     },
     {
-      "identity" : "tocropviewcontroller",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/TimOliver/TOCropViewController.git",
-      "state" : {
-        "revision" : "a634cb7cdfd580006e79a6e74e64417fe9e9783b",
-        "version" : "2.7.4"
-      }
-    },
-    {
-      "identity" : "weakmaptable",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ReactorKit/WeakMapTable.git",
-      "state" : {
-        "revision" : "cb05d64cef2bbf51e85c53adee937df46540a74e",
-        "version" : "1.2.1"
+      "identity": "weakmaptable",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/ReactorKit/WeakMapTable.git",
+      "state": {
+        "revision": "cb05d64cef2bbf51e85c53adee937df46540a74e",
+        "version": "1.2.1"
       }
     }
   ],
-  "version" : 3
+  "version": 3
 }

--- a/Frameworks/PanModal/LICENSE
+++ b/Frameworks/PanModal/LICENSE
@@ -1,0 +1,19 @@
+Copyright © 2018 Tiny Speck, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/Frameworks/PanModal/Package.swift
+++ b/Frameworks/PanModal/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "PanModal",
+    platforms: [.iOS(.v10)],
+    products: [
+        .library(
+            name: "PanModal",
+            targets: ["PanModal"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "PanModal",
+            dependencies: [],
+            path: "PanModal")
+    ],
+    swiftLanguageVersions: [.version("5.0")]
+)

--- a/Frameworks/PanModal/PanModal/Animator/PanModalAnimator.swift
+++ b/Frameworks/PanModal/PanModal/Animator/PanModalAnimator.swift
@@ -1,0 +1,40 @@
+//
+//  PanModalAnimator.swift
+//  PanModal
+//
+//  Copyright © 2019 Tiny Speck, Inc. All rights reserved.
+//
+
+#if os(iOS)
+import UIKit
+
+/**
+ Helper animation function to keep animations consistent.
+ */
+struct PanModalAnimator {
+
+    /**
+     Constant Animation Properties
+     */
+    struct Constants {
+        static let defaultTransitionDuration: TimeInterval = 0.5
+    }
+
+    static func animate(_ animations: @escaping PanModalPresentable.AnimationBlockType,
+                        config: PanModalPresentable?,
+                        _ completion: PanModalPresentable.AnimationCompletionType? = nil) {
+
+        let transitionDuration = config?.transitionDuration ?? Constants.defaultTransitionDuration
+        let springDamping = config?.springDamping ?? 1.0
+        let animationOptions = config?.transitionAnimationOptions ?? []
+
+        UIView.animate(withDuration: transitionDuration,
+                       delay: 0,
+                       usingSpringWithDamping: springDamping,
+                       initialSpringVelocity: 0,
+                       options: animationOptions,
+                       animations: animations,
+                       completion: completion)
+    }
+}
+#endif

--- a/Frameworks/PanModal/PanModal/Animator/PanModalPresentationAnimator.swift
+++ b/Frameworks/PanModal/PanModal/Animator/PanModalPresentationAnimator.swift
@@ -1,0 +1,172 @@
+//
+//  PanModalPresentationAnimator.swift
+//  PanModal
+//
+//  Copyright © 2019 Tiny Speck, Inc. All rights reserved.
+//
+
+#if os(iOS)
+import UIKit
+
+/**
+ Handles the animation of the presentedViewController as it is presented or dismissed.
+
+ This is a vertical animation that
+ - Animates up from the bottom of the screen
+ - Dismisses from the top to the bottom of the screen
+
+ This can be used as a standalone object for transition animation,
+ but is primarily used in the PanModalPresentationDelegate for handling pan modal transitions.
+
+ - Note: The presentedViewController can conform to PanModalPresentable to adjust
+ it's starting position through manipulating the shortFormHeight
+ */
+
+public class PanModalPresentationAnimator: NSObject {
+
+    /**
+     Enum representing the possible transition styles
+     */
+    public enum TransitionStyle {
+        case presentation
+        case dismissal
+    }
+
+    // MARK: - Properties
+
+    /**
+     The transition style
+     */
+    private let transitionStyle: TransitionStyle
+
+    /**
+     Haptic feedback generator (during presentation)
+     */
+    private var feedbackGenerator: UISelectionFeedbackGenerator?
+
+    // MARK: - Initializers
+
+    required public init(transitionStyle: TransitionStyle) {
+        self.transitionStyle = transitionStyle
+        super.init()
+
+        /**
+         Prepare haptic feedback, only during the presentation state
+         */
+        if case .presentation = transitionStyle {
+            feedbackGenerator = UISelectionFeedbackGenerator()
+            feedbackGenerator?.prepare()
+        }
+    }
+
+    /**
+     Animate presented view controller presentation
+     */
+    private func animatePresentation(transitionContext: UIViewControllerContextTransitioning) {
+
+        guard
+            let toVC = transitionContext.viewController(forKey: .to),
+            let fromVC = transitionContext.viewController(forKey: .from)
+            else { return }
+
+        let presentable = panModalLayoutType(from: transitionContext)
+
+        // Calls viewWillAppear and viewWillDisappear
+        fromVC.beginAppearanceTransition(false, animated: true)
+        
+        // Presents the view in shortForm position, initially
+        let yPos: CGFloat = presentable?.shortFormYPos ?? 0.0
+
+        // Use panView as presentingView if it already exists within the containerView
+        let panView: UIView = transitionContext.containerView.panContainerView ?? toVC.view
+
+        // Move presented view offscreen (from the bottom)
+        panView.frame = transitionContext.finalFrame(for: toVC)
+        panView.frame.origin.y = transitionContext.containerView.frame.height
+
+        // Haptic feedback
+        if presentable?.isHapticFeedbackEnabled == true {
+            feedbackGenerator?.selectionChanged()
+        }
+
+        PanModalAnimator.animate({
+            panView.frame.origin.y = yPos
+        }, config: presentable) { [weak self] didComplete in
+            // Calls viewDidAppear and viewDidDisappear
+            fromVC.endAppearanceTransition()
+            transitionContext.completeTransition(didComplete)
+            self?.feedbackGenerator = nil
+        }
+    }
+
+    /**
+     Animate presented view controller dismissal
+     */
+    private func animateDismissal(transitionContext: UIViewControllerContextTransitioning) {
+
+        guard
+            let toVC = transitionContext.viewController(forKey: .to),
+            let fromVC = transitionContext.viewController(forKey: .from)
+            else { return }
+
+        // Calls viewWillAppear and viewWillDisappear
+        toVC.beginAppearanceTransition(true, animated: true)
+        
+        let presentable = panModalLayoutType(from: transitionContext)
+        let panView: UIView = transitionContext.containerView.panContainerView ?? fromVC.view
+
+        PanModalAnimator.animate({
+            panView.frame.origin.y = transitionContext.containerView.frame.height
+        }, config: presentable) { didComplete in
+            fromVC.view.removeFromSuperview()
+            // Calls viewDidAppear and viewDidDisappear
+            toVC.endAppearanceTransition()
+            transitionContext.completeTransition(didComplete)
+        }
+    }
+
+    /**
+     Extracts the PanModal from the transition context, if it exists
+     */
+    private func panModalLayoutType(from context: UIViewControllerContextTransitioning) -> PanModalPresentable.LayoutType? {
+        switch transitionStyle {
+        case .presentation:
+            return context.viewController(forKey: .to) as? PanModalPresentable.LayoutType
+        case .dismissal:
+            return context.viewController(forKey: .from) as? PanModalPresentable.LayoutType
+        }
+    }
+
+}
+
+// MARK: - UIViewControllerAnimatedTransitioning Delegate
+
+extension PanModalPresentationAnimator: UIViewControllerAnimatedTransitioning {
+
+    /**
+     Returns the transition duration
+     */
+    public func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
+
+        guard
+            let context = transitionContext,
+            let presentable = panModalLayoutType(from: context)
+            else { return PanModalAnimator.Constants.defaultTransitionDuration }
+
+        return presentable.transitionDuration
+    }
+
+    /**
+     Performs the appropriate animation based on the transition style
+     */
+    public func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+        switch transitionStyle {
+        case .presentation:
+            animatePresentation(transitionContext: transitionContext)
+        case .dismissal:
+            animateDismissal(transitionContext: transitionContext)
+        }
+    }
+
+}
+#endif

--- a/Frameworks/PanModal/PanModal/Controller/PanModalPresentationController.swift
+++ b/Frameworks/PanModal/PanModal/Controller/PanModalPresentationController.swift
@@ -1,0 +1,896 @@
+//
+//  PanModalPresentationController.swift
+//  PanModal
+//
+//  Copyright © 2019 Tiny Speck, Inc. All rights reserved.
+//
+
+#if os(iOS)
+import UIKit
+
+/**
+ The PanModalPresentationController is the middle layer between the presentingViewController
+ and the presentedViewController.
+
+ It controls the coordination between the individual transition classes as well as
+ provides an abstraction over how the presented view is presented & displayed.
+
+ For example, we add a drag indicator view above the presented view and
+ a background overlay between the presenting & presented view.
+
+ The presented view's layout configuration & presentation is defined using the PanModalPresentable.
+
+ By conforming to the PanModalPresentable protocol & overriding values
+ the presented view can define its layout configuration & presentation.
+ */
+open class PanModalPresentationController: UIPresentationController {
+
+    /**
+     Enum representing the possible presentation states
+     */
+    public enum PresentationState {
+        case shortForm
+        case longForm
+    }
+
+    /**
+     Constants
+     */
+    struct Constants {
+        static let indicatorYOffset = CGFloat(8.0)
+        static let snapMovementSensitivity = CGFloat(0.7)
+        static let dragIndicatorSize = CGSize(width: 36.0, height: 5.0)
+    }
+
+    // MARK: - Properties
+
+    /**
+     A flag to track if the presented view is animating
+     */
+    private var isPresentedViewAnimating = false
+
+    /**
+     A flag to determine if scrolling should seamlessly transition
+     from the pan modal container view to the scroll view
+     once the scroll limit has been reached.
+     */
+    private var extendsPanScrolling = true
+
+    /**
+     A flag to determine if scrolling should be limited to the longFormHeight.
+     Return false to cap scrolling at .max height.
+     */
+    private var anchorModalToLongForm = true
+
+    /**
+     The y content offset value of the embedded scroll view
+     */
+    private var scrollViewYOffset: CGFloat = 0.0
+
+    /**
+     An observer for the scroll view content offset
+     */
+    private var scrollObserver: NSKeyValueObservation?
+
+    // store the y positions so we don't have to keep re-calculating
+
+    /**
+     The y value for the short form presentation state
+     */
+    private var shortFormYPosition: CGFloat = 0
+
+    /**
+     The y value for the long form presentation state
+     */
+    private var longFormYPosition: CGFloat = 0
+
+    /**
+     Determine anchored Y postion based on the `anchorModalToLongForm` flag
+     */
+    private var anchoredYPosition: CGFloat {
+        let defaultTopOffset = presentable?.topOffset ?? 0
+        return anchorModalToLongForm ? longFormYPosition : defaultTopOffset
+    }
+
+    /**
+     Configuration object for PanModalPresentationController
+     */
+    private var presentable: PanModalPresentable? {
+        return presentedViewController as? PanModalPresentable
+    }
+
+    // MARK: - Views
+
+    /**
+     Background view used as an overlay over the presenting view
+     */
+    private lazy var backgroundView: DimmedView = {
+        let view: DimmedView
+        if let color = presentable?.panModalBackgroundColor {
+            view = DimmedView(dimColor: color)
+        } else {
+            view = DimmedView()
+        }
+        view.didTap = { [weak self] _ in
+            if self?.presentable?.allowsTapToDismiss == true {
+                self?.presentedViewController.dismiss(animated: true)
+            }
+        }
+        return view
+    }()
+
+    /**
+     A wrapper around the presented view so that we can modify
+     the presented view apperance without changing
+     the presented view's properties
+     */
+    private lazy var panContainerView: PanContainerView = {
+        let frame = containerView?.frame ?? .zero
+        return PanContainerView(presentedView: presentedViewController.view, frame: frame)
+    }()
+
+    /**
+     Drag Indicator View
+     */
+    private lazy var dragIndicatorView: UIView = {
+        let view = UIView()
+        view.backgroundColor = presentable?.dragIndicatorBackgroundColor
+        view.layer.cornerRadius = Constants.dragIndicatorSize.height / 2.0
+        return view
+    }()
+
+    /**
+     Override presented view to return the pan container wrapper
+     */
+    public override var presentedView: UIView {
+        return panContainerView
+    }
+
+    // MARK: - Gesture Recognizers
+
+    /**
+     Gesture recognizer to detect & track pan gestures
+     */
+    private lazy var panGestureRecognizer: UIPanGestureRecognizer = {
+        let gesture = UIPanGestureRecognizer(target: self, action: #selector(didPanOnPresentedView(_ :)))
+        gesture.minimumNumberOfTouches = 1
+        gesture.maximumNumberOfTouches = 1
+        gesture.delegate = self
+        return gesture
+    }()
+
+    // MARK: - Deinitializers
+
+    deinit {
+        scrollObserver?.invalidate()
+    }
+
+    // MARK: - Lifecycle
+
+    override public func containerViewWillLayoutSubviews() {
+        super.containerViewWillLayoutSubviews()
+        configureViewLayout()
+    }
+
+    override public func presentationTransitionWillBegin() {
+
+        guard let containerView = containerView
+            else { return }
+
+        if panContainerView.frame == .zero {
+            adjustPresentedViewFrame()
+        }
+
+        layoutBackgroundView(in: containerView)
+        layoutPresentedView(in: containerView)
+        configureScrollViewInsets()
+
+        guard let coordinator = presentedViewController.transitionCoordinator else {
+            backgroundView.dimState = .max
+            return
+        }
+
+        coordinator.animate(alongsideTransition: { [weak self] _ in
+            self?.backgroundView.dimState = .max
+            self?.presentedViewController.setNeedsStatusBarAppearanceUpdate()
+        })
+    }
+
+    override public func presentationTransitionDidEnd(_ completed: Bool) {
+        if completed { return }
+
+        backgroundView.removeFromSuperview()
+    }
+
+    override public func dismissalTransitionWillBegin() {
+        presentable?.panModalWillDismiss()
+
+        guard let coordinator = presentedViewController.transitionCoordinator else {
+            backgroundView.dimState = .off
+            return
+        }
+
+        /**
+         Drag indicator is drawn outside of view bounds
+         so hiding it on view dismiss means avoiding visual bugs
+         */
+        coordinator.animate(alongsideTransition: { [weak self] _ in
+            self?.dragIndicatorView.alpha = 0.0
+            self?.backgroundView.dimState = .off
+            self?.presentingViewController.setNeedsStatusBarAppearanceUpdate()
+        })
+    }
+
+    override public func dismissalTransitionDidEnd(_ completed: Bool) {
+        if !completed { return }
+        
+        presentable?.panModalDidDismiss()
+    }
+
+    /**
+     Update presented view size in response to size class changes
+     */
+    override public func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+
+        coordinator.animate(alongsideTransition: { [weak self] _ in
+            guard
+                let self = self,
+                let presentable = self.presentable
+                else { return }
+
+            self.adjustPresentedViewFrame()
+            if presentable.shouldRoundTopCorners {
+                self.addRoundedCorners(to: self.presentedView)
+            }
+        })
+    }
+
+}
+
+// MARK: - Public Methods
+
+public extension PanModalPresentationController {
+
+    /**
+     Transition the PanModalPresentationController
+     to the given presentation state
+     */
+    func transition(to state: PresentationState) {
+
+        guard presentable?.shouldTransition(to: state) == true
+            else { return }
+
+        presentable?.willTransition(to: state)
+
+        switch state {
+        case .shortForm:
+            snap(toYPosition: shortFormYPosition)
+        case .longForm:
+            snap(toYPosition: longFormYPosition)
+        }
+    }
+
+    /**
+     Operations on the scroll view, such as content height changes,
+     or when inserting/deleting rows can cause the pan modal to jump,
+     caused by the pan modal responding to content offset changes.
+
+     To avoid this, you can call this method to perform scroll view updates,
+     with scroll observation temporarily disabled.
+     */
+    func performUpdates(_ updates: () -> Void) {
+
+        guard let scrollView = presentable?.panScrollable
+            else { return }
+
+        // Pause scroll observer
+        scrollObserver?.invalidate()
+        scrollObserver = nil
+
+        // Perform updates
+        updates()
+
+        // Resume scroll observer
+        trackScrolling(scrollView)
+        observe(scrollView: scrollView)
+    }
+
+    /**
+     Updates the PanModalPresentationController layout
+     based on values in the PanModalPresentable
+
+     - Note: This should be called whenever any
+     pan modal presentable value changes after the initial presentation
+     */
+    func setNeedsLayoutUpdate() {
+        configureViewLayout()
+        adjustPresentedViewFrame()
+        observe(scrollView: presentable?.panScrollable)
+        configureScrollViewInsets()
+    }
+
+}
+
+// MARK: - Presented View Layout Configuration
+
+private extension PanModalPresentationController {
+
+    /**
+     Boolean flag to determine if the presented view is anchored
+     */
+    var isPresentedViewAnchored: Bool {
+        if !isPresentedViewAnimating
+            && extendsPanScrolling
+            && presentedView.frame.minY.rounded() <= anchoredYPosition.rounded() {
+            return true
+        }
+
+        return false
+    }
+
+    /**
+     Adds the presented view to the given container view
+     & configures the view elements such as drag indicator, rounded corners
+     based on the pan modal presentable.
+     */
+    func layoutPresentedView(in containerView: UIView) {
+
+        /**
+         If the presented view controller does not conform to pan modal presentable
+         don't configure
+         */
+        guard let presentable = presentable
+            else { return }
+
+        /**
+         ⚠️ If this class is NOT used in conjunction with the PanModalPresentationAnimator
+         & PanModalPresentable, the presented view should be added to the container view
+         in the presentation animator instead of here
+         */
+        containerView.addSubview(presentedView)
+        containerView.addGestureRecognizer(panGestureRecognizer)
+
+        if presentable.showDragIndicator {
+            addDragIndicatorView(to: presentedView)
+        }
+
+        if presentable.shouldRoundTopCorners {
+            addRoundedCorners(to: presentedView)
+        }
+
+        setNeedsLayoutUpdate()
+        adjustPanContainerBackgroundColor()
+    }
+
+    /**
+     Reduce height of presentedView so that it sits at the bottom of the screen
+     */
+    func adjustPresentedViewFrame() {
+
+        guard let frame = containerView?.frame
+            else { return }
+
+        let adjustedSize = CGSize(width: frame.size.width, height: frame.size.height - anchoredYPosition)
+        let panFrame = panContainerView.frame
+        panContainerView.frame.size = frame.size
+        
+        if ![shortFormYPosition, longFormYPosition].contains(panFrame.origin.y) {
+            // if the container is already in the correct position, no need to adjust positioning
+            // (rotations & size changes cause positioning to be out of sync)
+            let yPosition = panFrame.origin.y - panFrame.height + frame.height
+            presentedView.frame.origin.y = max(yPosition, anchoredYPosition)
+        }
+        panContainerView.frame.origin.x = frame.origin.x
+        presentedViewController.view.frame = CGRect(origin: .zero, size: adjustedSize)
+    }
+
+    /**
+     Adds a background color to the pan container view
+     in order to avoid a gap at the bottom
+     during initial view presentation in longForm (when view bounces)
+     */
+    func adjustPanContainerBackgroundColor() {
+        panContainerView.backgroundColor = presentedViewController.view.backgroundColor
+            ?? presentable?.panScrollable?.backgroundColor
+    }
+
+    /**
+     Adds the background view to the view hierarchy
+     & configures its layout constraints.
+     */
+    func layoutBackgroundView(in containerView: UIView) {
+        containerView.addSubview(backgroundView)
+        backgroundView.translatesAutoresizingMaskIntoConstraints = false
+        backgroundView.topAnchor.constraint(equalTo: containerView.topAnchor).isActive = true
+        backgroundView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor).isActive = true
+        backgroundView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor).isActive = true
+        backgroundView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor).isActive = true
+    }
+
+    /**
+     Adds the drag indicator view to the view hierarchy
+     & configures its layout constraints.
+     */
+    func addDragIndicatorView(to view: UIView) {
+        view.addSubview(dragIndicatorView)
+        dragIndicatorView.translatesAutoresizingMaskIntoConstraints = false
+        dragIndicatorView.bottomAnchor.constraint(equalTo: view.topAnchor, constant: -Constants.indicatorYOffset).isActive = true
+        dragIndicatorView.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+        dragIndicatorView.widthAnchor.constraint(equalToConstant: Constants.dragIndicatorSize.width).isActive = true
+        dragIndicatorView.heightAnchor.constraint(equalToConstant: Constants.dragIndicatorSize.height).isActive = true
+    }
+
+    /**
+     Calculates & stores the layout anchor points & options
+     */
+    func configureViewLayout() {
+
+        guard let layoutPresentable = presentedViewController as? PanModalPresentable.LayoutType
+            else { return }
+
+        shortFormYPosition = layoutPresentable.shortFormYPos
+        longFormYPosition = layoutPresentable.longFormYPos
+        anchorModalToLongForm = layoutPresentable.anchorModalToLongForm
+        extendsPanScrolling = layoutPresentable.allowsExtendedPanScrolling
+
+        containerView?.isUserInteractionEnabled = layoutPresentable.isUserInteractionEnabled
+    }
+
+    /**
+     Configures the scroll view insets
+     */
+    func configureScrollViewInsets() {
+
+        guard
+            let scrollView = presentable?.panScrollable,
+            !scrollView.isScrolling
+            else { return }
+
+        /**
+         Disable vertical scroll indicator until we start to scroll
+         to avoid visual bugs
+         */
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.scrollIndicatorInsets = presentable?.scrollIndicatorInsets ?? .zero
+
+        /**
+         Set the appropriate contentInset as the configuration within this class
+         offsets it
+         */
+        scrollView.contentInset.bottom = presentingViewController.bottomLayoutGuide.length
+
+        /**
+         As we adjust the bounds during `handleScrollViewTopBounce`
+         we should assume that contentInsetAdjustmentBehavior will not be correct
+         */
+        if #available(iOS 11.0, *) {
+            scrollView.contentInsetAdjustmentBehavior = .never
+        }
+    }
+
+}
+
+// MARK: - Pan Gesture Event Handler
+
+private extension PanModalPresentationController {
+
+    /**
+     The designated function for handling pan gesture events
+     */
+    @objc func didPanOnPresentedView(_ recognizer: UIPanGestureRecognizer) {
+
+        guard
+            shouldRespond(to: recognizer),
+            let containerView = containerView
+            else {
+                recognizer.setTranslation(.zero, in: recognizer.view)
+                return
+        }
+
+        switch recognizer.state {
+        case .began, .changed:
+
+            /**
+             Respond accordingly to pan gesture translation
+             */
+            respond(to: recognizer)
+
+            /**
+             If presentedView is translated above the longForm threshold, treat as transition
+             */
+            if presentedView.frame.origin.y == anchoredYPosition && extendsPanScrolling {
+                presentable?.willTransition(to: .longForm)
+            }
+
+        default:
+
+            /**
+             Use velocity sensitivity value to restrict snapping
+             */
+            let velocity = recognizer.velocity(in: presentedView)
+
+            if isVelocityWithinSensitivityRange(velocity.y) {
+
+                /**
+                 If velocity is within the sensitivity range,
+                 transition to a presentation state or dismiss entirely.
+
+                 This allows the user to dismiss directly from long form
+                 instead of going to the short form state first.
+                 */
+                if velocity.y < 0 {
+                    transition(to: .longForm)
+
+                } else if (nearest(to: presentedView.frame.minY, inValues: [longFormYPosition, containerView.bounds.height]) == longFormYPosition
+                    && presentedView.frame.minY < shortFormYPosition) || presentable?.allowsDragToDismiss == false {
+                    transition(to: .shortForm)
+
+                } else {
+                    presentedViewController.dismiss(animated: true)
+                }
+
+            } else {
+
+                /**
+                 The `containerView.bounds.height` is used to determine
+                 how close the presented view is to the bottom of the screen
+                 */
+                let position = nearest(to: presentedView.frame.minY, inValues: [containerView.bounds.height, shortFormYPosition, longFormYPosition])
+
+                if position == longFormYPosition {
+                    transition(to: .longForm)
+
+                } else if position == shortFormYPosition || presentable?.allowsDragToDismiss == false {
+                    transition(to: .shortForm)
+
+                } else {
+                    presentedViewController.dismiss(animated: true)
+                }
+            }
+        }
+    }
+
+    /**
+     Determine if the pan modal should respond to the gesture recognizer.
+
+     If the pan modal is already being dragged & the delegate returns false, ignore until
+     the recognizer is back to it's original state (.began)
+
+     ⚠️ This is the only time we should be cancelling the pan modal gesture recognizer
+     */
+    func shouldRespond(to panGestureRecognizer: UIPanGestureRecognizer) -> Bool {
+        guard
+            presentable?.shouldRespond(to: panGestureRecognizer) == true ||
+                !(panGestureRecognizer.state == .began || panGestureRecognizer.state == .cancelled)
+            else {
+                panGestureRecognizer.isEnabled = false
+                panGestureRecognizer.isEnabled = true
+                return false
+        }
+        return !shouldFail(panGestureRecognizer: panGestureRecognizer)
+    }
+
+    /**
+     Communicate intentions to presentable and adjust subviews in containerView
+     */
+    func respond(to panGestureRecognizer: UIPanGestureRecognizer) {
+        presentable?.willRespond(to: panGestureRecognizer)
+
+        var yDisplacement = panGestureRecognizer.translation(in: presentedView).y
+
+        /**
+         If the presentedView is not anchored to long form, reduce the rate of movement
+         above the threshold
+         */
+        if presentedView.frame.origin.y < longFormYPosition {
+            yDisplacement /= 2.0
+        }
+        adjust(toYPosition: presentedView.frame.origin.y + yDisplacement)
+
+        panGestureRecognizer.setTranslation(.zero, in: presentedView)
+    }
+
+    /**
+     Determines if we should fail the gesture recognizer based on certain conditions
+
+     We fail the presented view's pan gesture recognizer if we are actively scrolling on the scroll view.
+     This allows the user to drag whole view controller from outside scrollView touch area.
+
+     Unfortunately, cancelling a gestureRecognizer means that we lose the effect of transition scrolling
+     from one view to another in the same pan gesture so don't cancel
+     */
+    func shouldFail(panGestureRecognizer: UIPanGestureRecognizer) -> Bool {
+
+        /**
+         Allow api consumers to override the internal conditions &
+         decide if the pan gesture recognizer should be prioritized.
+
+         ⚠️ This is the only time we should be cancelling the panScrollable recognizer,
+         for the purpose of ensuring we're no longer tracking the scrollView
+         */
+        guard !shouldPrioritize(panGestureRecognizer: panGestureRecognizer) else {
+            presentable?.panScrollable?.panGestureRecognizer.isEnabled = false
+            presentable?.panScrollable?.panGestureRecognizer.isEnabled = true
+            return false
+        }
+
+        guard
+            isPresentedViewAnchored,
+            let scrollView = presentable?.panScrollable,
+            scrollView.contentOffset.y > 0
+            else {
+                return false
+        }
+
+        let loc = panGestureRecognizer.location(in: presentedView)
+        return (scrollView.frame.contains(loc) || scrollView.isScrolling)
+    }
+
+    /**
+     Determine if the presented view's panGestureRecognizer should be prioritized over
+     embedded scrollView's panGestureRecognizer.
+     */
+    func shouldPrioritize(panGestureRecognizer: UIPanGestureRecognizer) -> Bool {
+        return panGestureRecognizer.state == .began &&
+            presentable?.shouldPrioritize(panModalGestureRecognizer: panGestureRecognizer) == true
+    }
+
+    /**
+     Check if the given velocity is within the sensitivity range
+     */
+    func isVelocityWithinSensitivityRange(_ velocity: CGFloat) -> Bool {
+        return (abs(velocity) - (1000 * (1 - Constants.snapMovementSensitivity))) > 0
+    }
+
+    func snap(toYPosition yPos: CGFloat) {
+        PanModalAnimator.animate({ [weak self] in
+            self?.adjust(toYPosition: yPos)
+            self?.isPresentedViewAnimating = true
+        }, config: presentable) { [weak self] didComplete in
+            self?.isPresentedViewAnimating = !didComplete
+        }
+    }
+
+    /**
+     Sets the y position of the presentedView & adjusts the backgroundView.
+     */
+    func adjust(toYPosition yPos: CGFloat) {
+        presentedView.frame.origin.y = max(yPos, anchoredYPosition)
+        
+        guard presentedView.frame.origin.y > shortFormYPosition else {
+            backgroundView.dimState = .max
+            return
+        }
+
+        let yDisplacementFromShortForm = presentedView.frame.origin.y - shortFormYPosition
+
+        /**
+         Once presentedView is translated below shortForm, calculate yPos relative to bottom of screen
+         and apply percentage to backgroundView alpha
+         */
+        backgroundView.dimState = .percent(1.0 - (yDisplacementFromShortForm / presentedView.frame.height))
+    }
+
+    /**
+     Finds the nearest value to a given number out of a given array of float values
+
+     - Parameters:
+        - number: reference float we are trying to find the closest value to
+        - values: array of floats we would like to compare against
+     */
+    func nearest(to number: CGFloat, inValues values: [CGFloat]) -> CGFloat {
+        guard let nearestVal = values.min(by: { abs(number - $0) < abs(number - $1) })
+            else { return number }
+        return nearestVal
+    }
+}
+
+// MARK: - UIScrollView Observer
+
+private extension PanModalPresentationController {
+
+    /**
+     Creates & stores an observer on the given scroll view's content offset.
+     This allows us to track scrolling without overriding the scrollView delegate
+     */
+    func observe(scrollView: UIScrollView?) {
+        scrollObserver?.invalidate()
+        scrollObserver = scrollView?.observe(\.contentOffset, options: .old) { [weak self] scrollView, change in
+
+            /**
+             Incase we have a situation where we have two containerViews in the same presentation
+             */
+            guard self?.containerView != nil
+                else { return }
+
+            self?.didPanOnScrollView(scrollView, change: change)
+        }
+    }
+
+    /**
+     Scroll view content offset change event handler
+
+     Also when scrollView is scrolled to the top, we disable the scroll indicator
+     otherwise glitchy behaviour occurs
+
+     This is also shown in Apple Maps (reverse engineering)
+     which allows us to seamlessly transition scrolling from the panContainerView to the scrollView
+     */
+    func didPanOnScrollView(_ scrollView: UIScrollView, change: NSKeyValueObservedChange<CGPoint>) {
+
+        guard
+            !presentedViewController.isBeingDismissed,
+            !presentedViewController.isBeingPresented
+            else { return }
+
+        if !isPresentedViewAnchored && scrollView.contentOffset.y > 0 {
+
+            /**
+             Hold the scrollView in place if we're actively scrolling and not handling top bounce
+             */
+            haltScrolling(scrollView)
+
+        } else if scrollView.isScrolling || isPresentedViewAnimating {
+
+            if isPresentedViewAnchored {
+                /**
+                 While we're scrolling upwards on the scrollView,
+                 store the last content offset position
+                 */
+                trackScrolling(scrollView)
+            } else {
+                /**
+                 Keep scroll view in place while we're panning on main view
+                 */
+                haltScrolling(scrollView)
+            }
+
+        } else if presentedViewController.view.isKind(of: UIScrollView.self)
+            && !isPresentedViewAnimating && scrollView.contentOffset.y <= 0 {
+
+            /**
+             In the case where we drag down quickly on the scroll view and let go,
+             `handleScrollViewTopBounce` adds a nice elegant touch.
+             */
+            handleScrollViewTopBounce(scrollView: scrollView, change: change)
+        } else {
+            trackScrolling(scrollView)
+        }
+    }
+
+    /**
+     Halts the scroll of a given scroll view & anchors it at the `scrollViewYOffset`
+     */
+    func haltScrolling(_ scrollView: UIScrollView) {
+        scrollView.setContentOffset(CGPoint(x: 0, y: scrollViewYOffset), animated: false)
+        scrollView.showsVerticalScrollIndicator = false
+    }
+
+    /**
+     As the user scrolls, track & save the scroll view y offset.
+     This helps halt scrolling when we want to hold the scroll view in place.
+     */
+    func trackScrolling(_ scrollView: UIScrollView) {
+        scrollViewYOffset = max(scrollView.contentOffset.y, 0)
+        scrollView.showsVerticalScrollIndicator = true
+    }
+
+    /**
+     To ensure that the scroll transition between the scrollView & the modal
+     is completely seamless, we need to handle the case where content offset is negative.
+
+     In this case, we follow the curve of the decelerating scroll view.
+     This gives the effect that the modal view and the scroll view are one view entirely.
+
+     - Note: This works best where the view behind view controller is a UIScrollView.
+     So, for example, a UITableViewController.
+     */
+    func handleScrollViewTopBounce(scrollView: UIScrollView, change: NSKeyValueObservedChange<CGPoint>) {
+
+        guard let oldYValue = change.oldValue?.y, scrollView.isDecelerating
+            else { return }
+
+        let yOffset = scrollView.contentOffset.y
+        let presentedSize = containerView?.frame.size ?? .zero
+
+        /**
+         Decrease the view bounds by the y offset so the scroll view stays in place
+         and we can still get updates on its content offset
+         */
+        presentedView.bounds.size = CGSize(width: presentedSize.width, height: presentedSize.height + yOffset)
+
+        if oldYValue > yOffset {
+            /**
+             Move the view in the opposite direction to the decreasing bounds
+             until half way through the deceleration so that it appears
+             as if we're transferring the scrollView drag momentum to the entire view
+             */
+            presentedView.frame.origin.y = longFormYPosition - yOffset
+        } else {
+            scrollViewYOffset = 0
+            snap(toYPosition: longFormYPosition)
+        }
+
+        scrollView.showsVerticalScrollIndicator = false
+    }
+}
+
+// MARK: - UIGestureRecognizerDelegate
+
+extension PanModalPresentationController: UIGestureRecognizerDelegate {
+
+    /**
+     Do not require any other gesture recognizers to fail
+     */
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return false
+    }
+
+    /**
+     Allow simultaneous gesture recognizers only when the other gesture recognizer's view
+     is the pan scrollable view
+     */
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return otherGestureRecognizer.view == presentable?.panScrollable
+    }
+}
+
+// MARK: - UIBezierPath
+
+private extension PanModalPresentationController {
+
+    /**
+     Draws top rounded corners on a given view
+     We have to set a custom path for corner rounding
+     because we render the dragIndicator outside of view bounds
+     */
+    func addRoundedCorners(to view: UIView) {
+        let radius = presentable?.cornerRadius ?? 0
+        let path = UIBezierPath(roundedRect: view.bounds,
+                                byRoundingCorners: [.topLeft, .topRight],
+                                cornerRadii: CGSize(width: radius, height: radius))
+
+        // Draw around the drag indicator view, if displayed
+        if presentable?.showDragIndicator == true {
+            let indicatorLeftEdgeXPos = view.bounds.width/2.0 - Constants.dragIndicatorSize.width/2.0
+            drawAroundDragIndicator(currentPath: path, indicatorLeftEdgeXPos: indicatorLeftEdgeXPos)
+        }
+
+        // Set path as a mask to display optional drag indicator view & rounded corners
+        let mask = CAShapeLayer()
+        mask.path = path.cgPath
+        view.layer.mask = mask
+
+        // Improve performance by rasterizing the layer
+        view.layer.shouldRasterize = true
+        view.layer.rasterizationScale = UIScreen.main.scale
+    }
+
+    /**
+     Draws a path around the drag indicator view
+     */
+    func drawAroundDragIndicator(currentPath path: UIBezierPath, indicatorLeftEdgeXPos: CGFloat) {
+
+        let totalIndicatorOffset = Constants.indicatorYOffset + Constants.dragIndicatorSize.height
+
+        // Draw around drag indicator starting from the left
+        path.addLine(to: CGPoint(x: indicatorLeftEdgeXPos, y: path.currentPoint.y))
+        path.addLine(to: CGPoint(x: path.currentPoint.x, y: path.currentPoint.y - totalIndicatorOffset))
+        path.addLine(to: CGPoint(x: path.currentPoint.x + Constants.dragIndicatorSize.width, y: path.currentPoint.y))
+        path.addLine(to: CGPoint(x: path.currentPoint.x, y: path.currentPoint.y + totalIndicatorOffset))
+    }
+}
+
+// MARK: - Helper Extensions
+
+private extension UIScrollView {
+
+    /**
+     A flag to determine if a scroll view is scrolling
+     */
+    var isScrolling: Bool {
+        return isDragging && !isDecelerating || isTracking
+    }
+}
+#endif

--- a/Frameworks/PanModal/PanModal/Delegate/PanModalPresentationDelegate.swift
+++ b/Frameworks/PanModal/PanModal/Delegate/PanModalPresentationDelegate.swift
@@ -1,0 +1,81 @@
+//
+//  PanModalPresentationDelegate.swift
+//  PanModal
+//
+//  Copyright © 2019 Tiny Speck, Inc. All rights reserved.
+//
+
+#if os(iOS)
+import UIKit
+
+/**
+ The PanModalPresentationDelegate conforms to the various transition delegates
+ and vends the appropriate object for each transition controller requested.
+
+ Usage:
+ ```
+ viewController.modalPresentationStyle = .custom
+ viewController.transitioningDelegate = PanModalPresentationDelegate.default
+ ```
+ */
+public class PanModalPresentationDelegate: NSObject {
+
+    /**
+     Returns an instance of the delegate, retained for the duration of presentation
+     */
+    public static var `default`: PanModalPresentationDelegate = {
+        return PanModalPresentationDelegate()
+    }()
+
+}
+
+extension PanModalPresentationDelegate: UIViewControllerTransitioningDelegate {
+
+    /**
+     Returns a modal presentation animator configured for the presenting state
+     */
+    public func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+        return PanModalPresentationAnimator(transitionStyle: .presentation)
+    }
+
+    /**
+     Returns a modal presentation animator configured for the dismissing state
+     */
+    public func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+        return PanModalPresentationAnimator(transitionStyle: .dismissal)
+    }
+
+    /**
+     Returns a modal presentation controller to coordinate the transition from the presenting
+     view controller to the presented view controller.
+
+     Changes in size class during presentation are handled via the adaptive presentation delegate
+     */
+    public func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
+        let controller = PanModalPresentationController(presentedViewController: presented, presenting: presenting)
+        controller.delegate = self
+        return controller
+    }
+
+}
+
+extension PanModalPresentationDelegate: UIAdaptivePresentationControllerDelegate, UIPopoverPresentationControllerDelegate {
+
+    /**
+     - Note: We do not adapt to size classes due to the introduction of the UIPresentationController
+     & deprecation of UIPopoverController (iOS 9), there is no way to have more than one
+     presentation controller in use during the same presentation
+
+     This is essential when transitioning from .popover to .custom on iPad split view... unless a custom popover view is also implemented
+     (popover uses UIPopoverPresentationController & we use PanModalPresentationController)
+     */
+
+    /**
+     Dismisses the presented view controller
+     */
+    public func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
+        return .none
+    }
+
+}
+#endif

--- a/Frameworks/PanModal/PanModal/Info.plist
+++ b/Frameworks/PanModal/PanModal/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/Frameworks/PanModal/PanModal/PanModal.h
+++ b/Frameworks/PanModal/PanModal/PanModal.h
@@ -1,0 +1,19 @@
+//
+//  PanModal.h
+//  PanModal
+//
+//  Created by Tosin A on 3/13/19.
+//  Copyright © 2019 Detail. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for PanModal.
+FOUNDATION_EXPORT double PanModalVersionNumber;
+
+//! Project version string for PanModal.
+FOUNDATION_EXPORT const unsigned char PanModalVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <PanModal/PublicHeader.h>
+
+

--- a/Frameworks/PanModal/PanModal/Presentable/PanModalHeight.swift
+++ b/Frameworks/PanModal/PanModal/Presentable/PanModalHeight.swift
@@ -1,0 +1,44 @@
+//
+//  PanModalHeight.swift
+//  PanModal
+//
+//  Copyright © 2019 Tiny Speck, Inc. All rights reserved.
+//
+
+#if os(iOS)
+import UIKit
+
+/**
+ An enum that defines the possible states of the height of a pan modal container view
+ for a given presentation state (shortForm, longForm)
+ */
+public enum PanModalHeight: Equatable {
+
+    /**
+     Sets the height to be the maximum height (+ topOffset)
+     */
+    case maxHeight
+
+    /**
+     Sets the height to be the max height with a specified top inset.
+     - Note: A value of 0 is equivalent to .maxHeight
+     */
+    case maxHeightWithTopInset(CGFloat)
+
+    /**
+     Sets the height to be the specified content height
+     */
+    case contentHeight(CGFloat)
+
+    /**
+     Sets the height to be the specified content height
+     & also ignores the bottomSafeAreaInset
+     */
+    case contentHeightIgnoringSafeArea(CGFloat)
+
+    /**
+     Sets the height to be the intrinsic content height
+     */
+    case intrinsicHeight
+}
+#endif

--- a/Frameworks/PanModal/PanModal/Presentable/PanModalPresentable+Defaults.swift
+++ b/Frameworks/PanModal/PanModal/Presentable/PanModalPresentable+Defaults.swift
@@ -1,0 +1,128 @@
+//
+//  PanModalPresentable+Defaults.swift
+//  PanModal
+//
+//  Copyright © 2018 Tiny Speck, Inc. All rights reserved.
+//
+
+#if os(iOS)
+import UIKit
+
+/**
+ Default values for the PanModalPresentable.
+ */
+public extension PanModalPresentable where Self: UIViewController {
+
+    var topOffset: CGFloat {
+        return topLayoutOffset + 21.0
+    }
+
+    var shortFormHeight: PanModalHeight {
+        return longFormHeight
+    }
+
+    var longFormHeight: PanModalHeight {
+
+        guard let scrollView = panScrollable
+            else { return .maxHeight }
+
+        // called once during presentation and stored
+        scrollView.layoutIfNeeded()
+        return .contentHeight(scrollView.contentSize.height)
+    }
+
+    var cornerRadius: CGFloat {
+        return 8.0
+    }
+
+    var springDamping: CGFloat {
+        return 0.8
+    }
+
+    var transitionDuration: Double {
+        return PanModalAnimator.Constants.defaultTransitionDuration
+    }
+
+    var transitionAnimationOptions: UIView.AnimationOptions {
+        return [.curveEaseInOut, .allowUserInteraction, .beginFromCurrentState]
+    }
+
+    var panModalBackgroundColor: UIColor {
+        return UIColor.black.withAlphaComponent(0.7)
+    }
+
+    var dragIndicatorBackgroundColor: UIColor {
+        return UIColor.lightGray
+    }
+
+    var scrollIndicatorInsets: UIEdgeInsets {
+        let top = shouldRoundTopCorners ? cornerRadius : 0
+        return UIEdgeInsets(top: CGFloat(top), left: 0, bottom: bottomLayoutOffset, right: 0)
+    }
+
+    var anchorModalToLongForm: Bool {
+        return true
+    }
+
+    var allowsExtendedPanScrolling: Bool {
+
+        guard let scrollView = panScrollable
+            else { return false }
+
+        scrollView.layoutIfNeeded()
+        return scrollView.contentSize.height > (scrollView.frame.height - bottomLayoutOffset)
+    }
+
+    var allowsDragToDismiss: Bool {
+        return true
+    }
+
+    var allowsTapToDismiss: Bool {
+        return true
+    }
+
+    var isUserInteractionEnabled: Bool {
+        return true
+    }
+
+    var isHapticFeedbackEnabled: Bool {
+        return true
+    }
+
+    var shouldRoundTopCorners: Bool {
+        return isPanModalPresented
+    }
+
+    var showDragIndicator: Bool {
+        return shouldRoundTopCorners
+    }
+
+    func shouldRespond(to panModalGestureRecognizer: UIPanGestureRecognizer) -> Bool {
+        return true
+    }
+
+    func willRespond(to panModalGestureRecognizer: UIPanGestureRecognizer) {
+
+    }
+
+    func shouldTransition(to state: PanModalPresentationController.PresentationState) -> Bool {
+        return true
+    }
+
+    func shouldPrioritize(panModalGestureRecognizer: UIPanGestureRecognizer) -> Bool {
+        return false
+    }
+
+    func willTransition(to state: PanModalPresentationController.PresentationState) {
+
+    }
+
+    func panModalWillDismiss() {
+
+    }
+
+    func panModalDidDismiss() {
+
+    }
+}
+#endif

--- a/Frameworks/PanModal/PanModal/Presentable/PanModalPresentable+LayoutHelpers.swift
+++ b/Frameworks/PanModal/PanModal/Presentable/PanModalPresentable+LayoutHelpers.swift
@@ -1,0 +1,120 @@
+//
+//  PanModalPresentable+LayoutHelpers.swift
+//  PanModal
+//
+//  Copyright © 2018 Tiny Speck, Inc. All rights reserved.
+//
+
+#if os(iOS)
+import UIKit
+
+/**
+ ⚠️ [Internal Only] ⚠️
+ Helper extensions that handle layout in the PanModalPresentationController
+ */
+extension PanModalPresentable where Self: UIViewController {
+
+    /**
+     Cast the presentation controller to PanModalPresentationController
+     so we can access PanModalPresentationController properties and methods
+     */
+    var presentedVC: PanModalPresentationController? {
+        return presentationController as? PanModalPresentationController
+    }
+
+    /**
+     Length of the top layout guide of the presenting view controller.
+     Gives us the safe area inset from the top.
+     */
+    var topLayoutOffset: CGFloat {
+
+        guard let rootVC = rootViewController
+            else { return 0}
+
+        if #available(iOS 11.0, *) { return rootVC.view.safeAreaInsets.top } else { return rootVC.topLayoutGuide.length }
+    }
+
+    /**
+     Length of the bottom layout guide of the presenting view controller.
+     Gives us the safe area inset from the bottom.
+     */
+    var bottomLayoutOffset: CGFloat {
+
+       guard let rootVC = rootViewController
+            else { return 0}
+
+        if #available(iOS 11.0, *) { return rootVC.view.safeAreaInsets.bottom } else { return rootVC.bottomLayoutGuide.length }
+    }
+
+    /**
+     Returns the short form Y position
+
+     - Note: If voiceover is on, the `longFormYPos` is returned.
+     We do not support short form when voiceover is on as it would make it difficult for user to navigate.
+     */
+    var shortFormYPos: CGFloat {
+
+        guard !UIAccessibility.isVoiceOverRunning
+            else { return longFormYPos }
+
+        let shortFormYPos = topMargin(from: shortFormHeight) + topOffset
+
+        // shortForm shouldn't exceed longForm
+        return max(shortFormYPos, longFormYPos)
+    }
+
+    /**
+     Returns the long form Y position
+
+     - Note: We cap this value to the max possible height
+     to ensure content is not rendered outside of the view bounds
+     */
+    var longFormYPos: CGFloat {
+        return max(topMargin(from: longFormHeight), topMargin(from: .maxHeight)) + topOffset
+    }
+
+    /**
+     Use the container view for relative positioning as this view's frame
+     is adjusted in PanModalPresentationController
+     */
+    var bottomYPos: CGFloat {
+
+        guard let container = presentedVC?.containerView
+            else { return view.bounds.height }
+
+        return container.bounds.size.height - topOffset
+    }
+
+    /**
+     Converts a given pan modal height value into a y position value
+     calculated from top of view
+     */
+    func topMargin(from: PanModalHeight) -> CGFloat {
+        switch from {
+        case .maxHeight:
+            return 0.0
+        case .maxHeightWithTopInset(let inset):
+            return inset
+        case .contentHeight(let height):
+            return bottomYPos - (height + bottomLayoutOffset)
+        case .contentHeightIgnoringSafeArea(let height):
+            return bottomYPos - height
+        case .intrinsicHeight:
+            view.layoutIfNeeded()
+            let targetSize = CGSize(width: (presentedVC?.containerView?.bounds ?? UIScreen.main.bounds).width,
+                                    height: UIView.layoutFittingCompressedSize.height)
+            let intrinsicHeight = view.systemLayoutSizeFitting(targetSize).height
+            return bottomYPos - (intrinsicHeight + bottomLayoutOffset)
+        }
+    }
+
+    private var rootViewController: UIViewController? {
+
+        guard let application = UIApplication.value(forKeyPath: #keyPath(UIApplication.shared)) as? UIApplication
+            else { return nil }
+
+        return application.keyWindow?.rootViewController
+    }
+
+}
+#endif

--- a/Frameworks/PanModal/PanModal/Presentable/PanModalPresentable+UIViewController.swift
+++ b/Frameworks/PanModal/PanModal/Presentable/PanModalPresentable+UIViewController.swift
@@ -1,0 +1,63 @@
+//
+//  PanModalPresentable+UIViewController.swift
+//  PanModal
+//
+//  Copyright © 2018 Tiny Speck, Inc. All rights reserved.
+//
+
+#if os(iOS)
+import UIKit
+
+/**
+ Extends PanModalPresentable with helper methods
+ when the conforming object is a UIViewController
+ */
+public extension PanModalPresentable where Self: UIViewController {
+
+    typealias AnimationBlockType = () -> Void
+    typealias AnimationCompletionType = (Bool) -> Void
+
+    /**
+     For Presentation, the object must be a UIViewController & confrom to the PanModalPresentable protocol.
+     */
+    typealias LayoutType = UIViewController & PanModalPresentable
+
+    /**
+     A function wrapper over the `transition(to state: PanModalPresentationController.PresentationState)`
+     function in the PanModalPresentationController.
+     */
+    func panModalTransition(to state: PanModalPresentationController.PresentationState) {
+        presentedVC?.transition(to: state)
+    }
+
+    /**
+     A function wrapper over the `setNeedsLayoutUpdate()`
+     function in the PanModalPresentationController.
+
+     - Note: This should be called whenever any of the values for the PanModalPresentable protocol are changed.
+     */
+    func panModalSetNeedsLayoutUpdate() {
+        presentedVC?.setNeedsLayoutUpdate()
+    }
+
+    /**
+     Operations on the scroll view, such as content height changes, or when inserting/deleting rows can cause the pan modal to jump,
+     caused by the pan modal responding to content offset changes.
+
+     To avoid this, you can call this method to perform scroll view updates, with scroll observation temporarily disabled.
+     */
+    func panModalPerformUpdates(_ updates: () -> Void) {
+        presentedVC?.performUpdates(updates)
+    }
+
+    /**
+     A function wrapper over the animate function in PanModalAnimator.
+
+     This can be used for animation consistency on views within the presented view controller.
+     */
+    func panModalAnimate(_ animationBlock: @escaping AnimationBlockType, _ completion: AnimationCompletionType? = nil) {
+        PanModalAnimator.animate(animationBlock, config: self, completion)
+    }
+
+}
+#endif

--- a/Frameworks/PanModal/PanModal/Presentable/PanModalPresentable.swift
+++ b/Frameworks/PanModal/PanModal/Presentable/PanModalPresentable.swift
@@ -1,0 +1,237 @@
+//
+//  PanModalPresentable.swift
+//  PanModal
+//
+//  Copyright © 2017 Tiny Speck, Inc. All rights reserved.
+//
+
+#if os(iOS)
+import UIKit
+
+/**
+ This is the configuration object for a view controller
+ that will be presented using the PanModal transition.
+
+ Usage:
+ ```
+ extension YourViewController: PanModalPresentable {
+    func shouldRoundTopCorners: Bool { return false }
+ }
+ ```
+ */
+public protocol PanModalPresentable: AnyObject {
+
+    /**
+     The scroll view embedded in the view controller.
+     Setting this value allows for seamless transition scrolling between the embedded scroll view
+     and the pan modal container view.
+     */
+    var panScrollable: UIScrollView? { get }
+
+    /**
+     The offset between the top of the screen and the top of the pan modal container view.
+
+     Default value is the topLayoutGuide.length + 21.0.
+     */
+    var topOffset: CGFloat { get }
+
+    /**
+     The height of the pan modal container view
+     when in the shortForm presentation state.
+
+     This value is capped to .max, if provided value exceeds the space available.
+
+     Default value is the longFormHeight.
+     */
+    var shortFormHeight: PanModalHeight { get }
+
+    /**
+     The height of the pan modal container view
+     when in the longForm presentation state.
+     
+     This value is capped to .max, if provided value exceeds the space available.
+
+     Default value is .max.
+     */
+    var longFormHeight: PanModalHeight { get }
+
+    /**
+     The corner radius used when `shouldRoundTopCorners` is enabled.
+
+     Default Value is 8.0.
+     */
+    var cornerRadius: CGFloat { get }
+
+    /**
+     The springDamping value used to determine the amount of 'bounce'
+     seen when transitioning to short/long form.
+
+     Default Value is 0.8.
+     */
+    var springDamping: CGFloat { get }
+
+    /**
+     The transitionDuration value is used to set the speed of animation during a transition,
+     including initial presentation.
+
+     Default value is 0.5.
+    */
+    var transitionDuration: Double { get }
+
+    /**
+     The animation options used when performing animations on the PanModal, utilized mostly
+     during a transition.
+
+     Default value is [.curveEaseInOut, .allowUserInteraction, .beginFromCurrentState].
+    */
+    var transitionAnimationOptions: UIView.AnimationOptions { get }
+
+    /**
+     The background view color.
+
+     - Note: This is only utilized at the very start of the transition.
+
+     Default Value is black with alpha component 0.7.
+    */
+    var panModalBackgroundColor: UIColor { get }
+
+    /**
+     The drag indicator view color.
+
+     Default value is light gray.
+    */
+    var dragIndicatorBackgroundColor: UIColor { get }
+
+    /**
+     We configure the panScrollable's scrollIndicatorInsets interally so override this value
+     to set custom insets.
+
+     - Note: Use `panModalSetNeedsLayoutUpdate()` when updating insets.
+     */
+    var scrollIndicatorInsets: UIEdgeInsets { get }
+
+    /**
+     A flag to determine if scrolling should be limited to the longFormHeight.
+     Return false to cap scrolling at .max height.
+
+     Default value is true.
+     */
+    var anchorModalToLongForm: Bool { get }
+
+    /**
+     A flag to determine if scrolling should seamlessly transition from the pan modal container view to
+     the embedded scroll view once the scroll limit has been reached.
+
+     Default value is false. Unless a scrollView is provided and the content height exceeds the longForm height.
+     */
+    var allowsExtendedPanScrolling: Bool { get }
+
+    /**
+     A flag to determine if dismissal should be initiated when swiping down on the presented view.
+
+     Return false to fallback to the short form state instead of dismissing.
+
+     Default value is true.
+     */
+    var allowsDragToDismiss: Bool { get }
+
+    /**
+     A flag to determine if dismissal should be initiated when tapping on the dimmed background view.
+
+     Default value is true.
+     */
+    var allowsTapToDismiss: Bool { get }
+
+    /**
+     A flag to toggle user interactions on the container view.
+
+     - Note: Return false to forward touches to the presentingViewController.
+
+     Default is true.
+    */
+    var isUserInteractionEnabled: Bool { get }
+
+    /**
+     A flag to determine if haptic feedback should be enabled during presentation.
+
+     Default value is true.
+     */
+    var isHapticFeedbackEnabled: Bool { get }
+
+    /**
+     A flag to determine if the top corners should be rounded.
+
+     Default value is true.
+     */
+    var shouldRoundTopCorners: Bool { get }
+
+    /**
+     A flag to determine if a drag indicator should be shown
+     above the pan modal container view.
+
+     Default value is true.
+     */
+    var showDragIndicator: Bool { get }
+
+    /**
+     Asks the delegate if the pan modal should respond to the pan modal gesture recognizer.
+     
+     Return false to disable movement on the pan modal but maintain gestures on the presented view.
+
+     Default value is true.
+     */
+    func shouldRespond(to panModalGestureRecognizer: UIPanGestureRecognizer) -> Bool
+
+    /**
+     Notifies the delegate when the pan modal gesture recognizer state is either
+     `began` or `changed`. This method gives the delegate a chance to prepare
+     for the gesture recognizer state change.
+
+     For example, when the pan modal view is about to scroll.
+
+     Default value is an empty implementation.
+     */
+    func willRespond(to panModalGestureRecognizer: UIPanGestureRecognizer)
+
+    /**
+     Asks the delegate if the pan modal gesture recognizer should be prioritized.
+
+     For example, you can use this to define a region
+     where you would like to restrict where the pan gesture can start.
+
+     If false, then we rely solely on the internal conditions of when a pan gesture
+     should succeed or fail, such as, if we're actively scrolling on the scrollView.
+
+     Default return value is false.
+     */
+    func shouldPrioritize(panModalGestureRecognizer: UIPanGestureRecognizer) -> Bool
+
+    /**
+     Asks the delegate if the pan modal should transition to a new state.
+
+     Default value is true.
+     */
+    func shouldTransition(to state: PanModalPresentationController.PresentationState) -> Bool
+
+    /**
+     Notifies the delegate that the pan modal is about to transition to a new state.
+
+     Default value is an empty implementation.
+     */
+    func willTransition(to state: PanModalPresentationController.PresentationState)
+
+    /**
+     Notifies the delegate that the pan modal is about to be dismissed.
+
+     Default value is an empty implementation.
+     */
+    func panModalWillDismiss()
+
+    /**
+     Notifies the delegate after the pan modal is dismissed.
+
+     Default value is an empty implementation.
+     */
+    func panModalDidDismiss()
+}
+#endif

--- a/Frameworks/PanModal/PanModal/Presenter/PanModalPresenter.swift
+++ b/Frameworks/PanModal/PanModal/Presenter/PanModalPresenter.swift
@@ -1,0 +1,35 @@
+//
+//  PanModalPresenter.swift
+//  PanModal
+//
+//  Copyright © 2019 Tiny Speck, Inc. All rights reserved.
+//
+
+#if os(iOS)
+import UIKit
+
+/**
+ A protocol for objects that will present a view controller as a PanModal
+
+ - Usage:
+ ```
+ viewController.presentPanModal(viewControllerToPresent: presentingVC,
+                                             sourceView: presentingVC.view,
+                                             sourceRect: .zero)
+ ```
+ */
+protocol PanModalPresenter: AnyObject {
+
+    /**
+     A flag that returns true if the current presented view controller
+     is using the PanModalPresentationDelegate
+     */
+    var isPanModalPresented: Bool { get }
+
+    /**
+     Presents a view controller that conforms to the PanModalPresentable protocol
+     */
+    func presentPanModal(_ viewControllerToPresent: PanModalPresentable.LayoutType, sourceView: UIView?, sourceRect: CGRect)
+
+}
+#endif

--- a/Frameworks/PanModal/PanModal/Presenter/UIViewController+PanModalPresenter.swift
+++ b/Frameworks/PanModal/PanModal/Presenter/UIViewController+PanModalPresenter.swift
@@ -1,0 +1,62 @@
+//
+//  UIViewController+PanModalPresenterProtocol.swift
+//  PanModal
+//
+//  Copyright © 2019 Tiny Speck, Inc. All rights reserved.
+//
+
+#if os(iOS)
+import UIKit
+
+/**
+ Extends the UIViewController to conform to the PanModalPresenter protocol
+ */
+extension UIViewController: PanModalPresenter {
+
+    /**
+     A flag that returns true if the topmost view controller in the navigation stack
+     was presented using the custom PanModal transition
+
+     - Warning: ⚠️ Calling `presentationController` in this function may cause a memory leak. ⚠️
+
+     In most cases, this check will be used early in the view lifecycle and unfortunately,
+     there's an Apple bug that causes multiple presentationControllers to be created if
+     the presentationController is referenced here and called too early resulting in
+     a strong reference to this view controller and in turn, creating a memory leak.
+     */
+    public var isPanModalPresented: Bool {
+        return (transitioningDelegate as? PanModalPresentationDelegate) != nil
+    }
+
+    /**
+     Configures a view controller for presentation using the PanModal transition
+
+     - Parameters:
+        - viewControllerToPresent: The view controller to be presented
+        - sourceView: The view containing the anchor rectangle for the popover.
+        - sourceRect: The rectangle in the specified view in which to anchor the popover.
+
+     - Note: sourceView & sourceRect are only required for presentation on an iPad.
+     */
+    public func presentPanModal(_ viewControllerToPresent: PanModalPresentable.LayoutType, sourceView: UIView? = nil, sourceRect: CGRect = .zero) {
+
+        /**
+         Here, we deliberately do not check for size classes. More info in `PanModalPresentationDelegate`
+         */
+
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            viewControllerToPresent.modalPresentationStyle = .popover
+            viewControllerToPresent.popoverPresentationController?.sourceRect = sourceRect
+            viewControllerToPresent.popoverPresentationController?.sourceView = sourceView ?? view
+            viewControllerToPresent.popoverPresentationController?.delegate = PanModalPresentationDelegate.default
+        } else {
+            viewControllerToPresent.modalPresentationStyle = .custom
+            viewControllerToPresent.modalPresentationCapturesStatusBarAppearance = true
+            viewControllerToPresent.transitioningDelegate = PanModalPresentationDelegate.default
+        }
+
+        present(viewControllerToPresent, animated: true, completion: nil)
+    }
+
+}
+#endif

--- a/Frameworks/PanModal/PanModal/View/DimmedView.swift
+++ b/Frameworks/PanModal/PanModal/View/DimmedView.swift
@@ -1,0 +1,76 @@
+//
+//  DimmedView.swift
+//  PanModal
+//
+//  Copyright © 2017 Tiny Speck, Inc. All rights reserved.
+//
+
+#if os(iOS)
+import UIKit
+
+/**
+ A dim view for use as an overlay over content you want dimmed.
+ */
+public class DimmedView: UIView {
+
+    /**
+     Represents the possible states of the dimmed view.
+     max, off or a percentage of dimAlpha.
+     */
+    enum DimState {
+        case max
+        case off
+        case percent(CGFloat)
+    }
+
+    // MARK: - Properties
+
+    /**
+     The state of the dimmed view
+     */
+    var dimState: DimState = .off {
+        didSet {
+            switch dimState {
+            case .max:
+                alpha = 1.0
+            case .off:
+                alpha = 0.0
+            case .percent(let percentage):
+                alpha = max(0.0, min(1.0, percentage))
+            }
+        }
+    }
+
+    /**
+     The closure to be executed when a tap occurs
+     */
+    var didTap: ((_ recognizer: UIGestureRecognizer) -> Void)?
+
+    /**
+     Tap gesture recognizer
+     */
+    private lazy var tapGesture: UIGestureRecognizer = {
+        return UITapGestureRecognizer(target: self, action: #selector(didTapView))
+    }()
+
+    // MARK: - Initializers
+
+    init(dimColor: UIColor = UIColor.black.withAlphaComponent(0.7)) {
+        super.init(frame: .zero)
+        alpha = 0.0
+        backgroundColor = dimColor
+        addGestureRecognizer(tapGesture)
+    }
+
+    required public init?(coder aDecoder: NSCoder) {
+        fatalError()
+    }
+
+    // MARK: - Event Handlers
+
+    @objc private func didTapView() {
+        didTap?(tapGesture)
+    }
+
+}
+#endif

--- a/Frameworks/PanModal/PanModal/View/PanContainerView.swift
+++ b/Frameworks/PanModal/PanModal/View/PanContainerView.swift
@@ -1,0 +1,44 @@
+//
+//  PanContainerView.swift
+//  PanModal
+//
+//  Copyright © 2018 Tiny Speck, Inc. All rights reserved.
+//
+
+#if os(iOS)
+import UIKit
+
+/**
+ A view wrapper around the presented view in a PanModal transition.
+
+ This allows us to make modifications to the presented view without
+ having to do those changes directly on the view
+ */
+class PanContainerView: UIView {
+
+    init(presentedView: UIView, frame: CGRect) {
+        super.init(frame: frame)
+        addSubview(presentedView)
+    }
+
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+}
+
+extension UIView {
+
+    /**
+     Convenience property for retrieving a PanContainerView instance
+     from the view hierachy
+     */
+    var panContainerView: PanContainerView? {
+        return subviews.first(where: { view -> Bool in
+            view is PanContainerView
+        }) as? PanContainerView
+    }
+
+}
+#endif


### PR DESCRIPTION
## 원인
PanModal 1.2.7의 iOS 17.1+ 버그입니다. UIKit 프레젠테이션 순서 변경으로 `PanModalPresentationController`의 `panContainerView`(lazy)가 `containerView`가 nil인 시점에 생성되면 frame이 `.zero`가 되고, 이후 보정되지 않아 **딤 배경만 그려지고 시트 패널이 화면에 노출되지 않습니다.**

- 업스트림 이슈: slackhq/PanModal#202 (동일 증상 다수 보고, 라이브러리는 2025-11 아카이브됨)
- 미머지 수정: slackhq/PanModal#204

**재현 미디어 확인 결과** (JIRA 첨부 영상/스크린샷 분석):
- TH-1192 영상: 리뷰 상세 → "신고하기" 탭 → 딤만 깔리고 신고 시트 미노출 → 배경 탭으로 딤 해제
- TH-1193 "조치후 발생 현상" 스크린샷: 동일하게 화면 전체 딤 상태에서 시트 없음

→ 두 티켓의 공통 근본 원인이며, 이 PR로 리뷰 상세의 신고/자주쓰는 문구/문구 추가 시트 및 앱 내 모든 PanModal 시트(계좌 은행 선택, 메시지 발송 등)에 동일하게 적용됩니다.

## 재현 경로
1. 리뷰 상세 진입
2. 우측 상단 "신고하기" 탭 (또는 "자주 쓰는 문구" 탭)
3. 실제: 화면이 어두워지기만 하고 시트가 나타나지 않음 / 기대: 바텀시트 노출

## 수정 방향
라이브러리가 아카이브되어 업스트림 수정이 불가하므로, **PanModal 1.2.7 소스를 `Frameworks/PanModal` 로컬 Swift Package로 벤더링**하고 PR #204의 수정을 적용했습니다. 외부 개인 포크 의존 없이 레포 안에서 자체 관리됩니다.

**수정 내용:**
- `Frameworks/PanModal/`: PanModal 1.2.7 소스 벤더링 (+ LICENSE)
- `Frameworks/PanModal/PanModal/Controller/PanModalPresentationController.swift`: `presentationTransitionWillBegin()`에서 `panContainerView.frame == .zero`인 경우 `adjustPresentedViewFrame()` 호출 (업스트림 PR #204와 동일한 4줄 패치)
- `project.pbxproj`: PanModal 패키지 참조를 원격(slackhq 1.2.7 exact) → 로컬(`Frameworks/PanModal`)로 전환
- `Package.resolved`: PanModal 핀 제거

## Before / After (iOS 26.2 시뮬레이터)

**시뮬레이터에서 실제 앱 화면으로 버그 재현에 성공**했습니다. 로그인 없이 검증하기 위해 mock `ReviewRepository`를 주입해 리뷰 상세 화면을 직접 띄우는 임시 하네스를 각 브랜치 작업트리에만 얹어 촬영했습니다 (하네스 코드는 커밋되지 않음).

| 화면 | Before (develop) | After (이 PR) |
| --- | --- | --- |
| 신고하기 탭 | <img src="https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-manager-ios/releases/download/verification-assets/TH-1192-before.png" width="300"> | <img src="https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-manager-ios/releases/download/verification-assets/TH-1192-after.png" width="300"> |
| 자주 쓰는 문구 탭 | <img src="https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-manager-ios/releases/download/verification-assets/TH-1193-before.png" width="300"> | <img src="https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-manager-ios/releases/download/verification-assets/TH-1193-after.png" width="300"> |

- Before: 딤만 깔리고 시트 미노출 — JIRA 첨부 실기기 영상과 동일한 증상
- After: 신고 시트/자주 쓰는 문구 시트 정상 노출 (TH-1192, TH-1193의 사용자 증상 모두 이 패치로 해소)
- 스크린샷 원본: verification-assets 릴리스(Pre-release)

## 검증
- ✅ Debug 빌드 성공 (3dollar-in-my-pocket-manager-dev, iOS 26.2 시뮬레이터)
- ✅ **시뮬레이터 Before/After 재현·수정 확인** (위 표) — 데모 앱에서는 재현되지 않았지만 실제 앱 시트에서는 재현되어 패치 효과까지 검증됨
- ✅ 패치는 `frame == .zero`(버그 상태)일 때만 동작하는 가드라 기존 정상 동작에는 no-op
- 실기기(iOS 17.1+) 확인도 배포 전 권장

## 영향 범위
- 앱 내 모든 PanModal 바텀시트 (리뷰 신고, 자주쓰는 문구, 문구 추가/수정, 은행 선택, 메시지 발송 등)
- 의존성 관리 방식 변경: SPM 원격 → 로컬 패키지 (버전 업데이트는 벤더링 소스 갱신으로 수행)
- **리스크:** 낮음 (소스는 1.2.7 동일 + 4줄 가드 패치)

## 관련 이슈
- Jira: TH-1192 (동일 원인: TH-1193)
- slackhq/PanModal#202, slackhq/PanModal#204
