### PR TITLE
TH-1062 : 가게 정보 카테고리 이름 긴 경우 잘림 수정

### DIFF
--- a/3dollar-in-my-pocket-manager/domains/MyStore/MyStoreInfo/Cell/MyStoreInfoOverviewCell.swift
+++ b/3dollar-in-my-pocket-manager/domains/MyStore/MyStoreInfo/Cell/MyStoreInfoOverviewCell.swift
@@ -5,6 +5,44 @@ import Kingfisher
 final class MyStoreInfoOverviewCell: BaseCollectionViewCell {
     enum Layout {
         static let height: CGFloat = 477
+        static let categorySpacing: CGFloat = 4
+        static let categoryFont: UIFont = .systemFont(ofSize: 17)
+        static var categoryRowHeight: CGFloat {
+            return ceil(categoryFont.lineHeight) + 8
+        }
+        static var categoryMaxWidth: CGFloat {
+            return UIUtils.windowBounds.width - 80
+        }
+
+        static func calculateHeight(store: BossStoreResponse) -> CGFloat {
+            let lineCount = max(splitCategoriesIntoLines(store.categories).count, 1)
+            return height + CGFloat(lineCount - 1) * (categoryRowHeight + categorySpacing)
+        }
+
+        static func splitCategoriesIntoLines(_ categories: [StoreFoodCategoryResponse]) -> [[StoreFoodCategoryResponse]] {
+            var lines: [[StoreFoodCategoryResponse]] = []
+            var currentLine: [StoreFoodCategoryResponse] = []
+            var currentWidth: CGFloat = 0
+
+            for category in categories {
+                let chipWidth = ceil(category.name.width(font: categoryFont, height: categoryRowHeight)) + 16
+                let spacing = currentLine.isEmpty ? 0 : categorySpacing
+
+                if currentLine.isEmpty.isNot && currentWidth + spacing + chipWidth > categoryMaxWidth {
+                    lines.append(currentLine)
+                    currentLine = [category]
+                    currentWidth = chipWidth
+                } else {
+                    currentLine.append(category)
+                    currentWidth += spacing + chipWidth
+                }
+            }
+
+            if currentLine.isEmpty.isNot {
+                lines.append(currentLine)
+            }
+            return lines
+        }
     }
     
     private lazy var photoCollectionView: UICollectionView = {
@@ -37,10 +75,9 @@ final class MyStoreInfoOverviewCell: BaseCollectionViewCell {
     
     private let categoryStackView: UIStackView = {
         let stackView = UIStackView()
-        stackView.axis = .horizontal
-        stackView.spacing = 4
-        stackView.distribution = .equalSpacing
-        stackView.alignment = .fill
+        stackView.axis = .vertical
+        stackView.spacing = Layout.categorySpacing
+        stackView.alignment = .center
         return stackView
     }()
     
@@ -127,22 +164,32 @@ final class MyStoreInfoOverviewCell: BaseCollectionViewCell {
         photoCountLabel.bind(count: 1, total: store.representativeImages.count)
         photoCollectionView.reloadData()
         
-        for category in store.categories {
-            let categoryLagel = PaddingLabel(
-                topInset: 4,
-                bottomInset: 4,
-                leftInset: 8,
-                rightInset: 8
-            ).then {
-                $0.backgroundColor = UIColor(r: 0, g: 198, b: 103, a: 0.1)
-                $0.textColor = .green
-                $0.layer.cornerRadius = 8
-                $0.text = category.name
-                $0.layer.masksToBounds = true
-                $0.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        for line in Layout.splitCategoriesIntoLines(store.categories) {
+            let lineStackView = UIStackView()
+            lineStackView.axis = .horizontal
+            lineStackView.spacing = Layout.categorySpacing
+            lineStackView.alignment = .fill
+
+            for category in line {
+                let categoryLagel = PaddingLabel(
+                    topInset: 4,
+                    bottomInset: 4,
+                    leftInset: 8,
+                    rightInset: 8
+                ).then {
+                    $0.backgroundColor = UIColor(r: 0, g: 198, b: 103, a: 0.1)
+                    $0.textColor = .green
+                    $0.font = Layout.categoryFont
+                    $0.layer.cornerRadius = 8
+                    $0.text = category.name
+                    $0.layer.masksToBounds = true
+                    $0.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+                }
+
+                lineStackView.addArrangedSubview(categoryLagel)
             }
-            
-            categoryStackView.addArrangedSubview(categoryLagel)
+
+            categoryStackView.addArrangedSubview(lineStackView)
         }
         
         snsValueLabel.text = store.snsUrl ?? Strings.EditStoreInfo.notExist

--- a/3dollar-in-my-pocket-manager/domains/MyStore/MyStoreInfo/MyStoreInfoViewController.swift
+++ b/3dollar-in-my-pocket-manager/domains/MyStore/MyStoreInfo/MyStoreInfoViewController.swift
@@ -85,23 +85,14 @@ final class MyStoreInfoViewController: BaseViewController {
     private func createCollectionViewLayout() -> UICollectionViewLayout {
         return UICollectionViewCompositionalLayout { [weak self] sectionIndex, _ in
             guard let self,
-                  let sectionType = dataSource.sectionIdentifier(section: sectionIndex)?.type else {
+                  let sectionIdentifier = dataSource.sectionIdentifier(section: sectionIndex) else {
                 fatalError("정의되지 않은 섹션입니다.")
             }
-            
+            let sectionType = sectionIdentifier.type
+
             switch sectionType {
             case .overview:
-                let item = NSCollectionLayoutItem(layoutSize: .init(
-                    widthDimension: .fractionalWidth(1),
-                    heightDimension: .absolute(MyStoreInfoOverviewCell.Layout.height)
-                ))
-                let group = NSCollectionLayoutGroup.horizontal(layoutSize: .init(
-                    widthDimension: .fractionalWidth(1),
-                    heightDimension: .absolute(MyStoreInfoOverviewCell.Layout.height)
-                ), subitems: [item])
-                let section = NSCollectionLayoutSection(group: group)
-                
-                return section
+                return createOverviewSection(sectionIdentifier: sectionIdentifier)
             case .introduction:
                 let item = NSCollectionLayoutItem(layoutSize: .init(
                     widthDimension: .fractionalWidth(1),
@@ -193,6 +184,23 @@ final class MyStoreInfoViewController: BaseViewController {
         }
     }
     
+    private func createOverviewSection(sectionIdentifier: MyStoreInfoSection) -> NSCollectionLayoutSection {
+        var height = MyStoreInfoOverviewCell.Layout.height
+        if case .overView(let store) = sectionIdentifier.items.first {
+            height = MyStoreInfoOverviewCell.Layout.calculateHeight(store: store)
+        }
+
+        let item = NSCollectionLayoutItem(layoutSize: .init(
+            widthDimension: .fractionalWidth(1),
+            heightDimension: .absolute(height)
+        ))
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: .init(
+            widthDimension: .fractionalWidth(1),
+            heightDimension: .absolute(height)
+        ), subitems: [item])
+        return NSCollectionLayoutSection(group: group)
+    }
+
     private func handleRoute(_ route: MyStoreInfoViewModel.Route) {
         switch route {
         case .pushEditStoreInfo(let viewModel):


### PR DESCRIPTION
## 원인
가게 정보 탭 overview 카드의 `categoryStackView`(가로 스택)가 `centerX` + `top` 제약만 갖고 있어 폭 제한이 없습니다. 긴 이름의 카테고리 3개를 선택하면 스택 전체 너비가 카드(containerView) 폭을 초과해 화면 밖으로 삐져나갑니다.

**문제 코드:** `MyStoreInfoOverviewCell.swift` — `categoryStackView` 제약 (기존 line 201~204)

## 재현 경로
1. 이름이 긴 카테고리 3개를 대표 카테고리로 선택
2. 가게 정보 탭(2탭) 진입
3. 실제: 카테고리 칩이 카드 영역 밖으로 잘림 / 기대: 영역 안에 표시

## 수정 방향
티켓의 제안대로 **칩 너비를 계산해 카드 폭을 초과하면 다음 줄로 래핑하고, 줄 단위 가운데 정렬**로 표시합니다.

**수정 내용:**
- `MyStoreInfoOverviewCell.swift`
  - `categoryStackView`를 세로 스택(가운데 정렬)으로 변경, 카테고리를 줄 단위 가로 스택으로 감싸 추가
  - `Layout.splitCategoriesIntoLines()`: 칩 너비(텍스트 + 좌우 인셋 16) 합산으로 줄 분할 계산
  - `Layout.calculateHeight(store:)`: 줄 수에 따라 셀 높이 동적 계산 (1줄이면 기존 477 유지)
  - 칩에 측정 기준 폰트(`Layout.categoryFont`)를 명시해 계산·렌더링 일치 보장 (기존 UILabel 기본 폰트와 동일한 systemFont 17)
- `MyStoreInfoViewController.swift`: overview 섹션 높이를 `.absolute(477)` 고정 대신 `calculateHeight(store:)` 결과로 설정 (`createOverviewSection` 헬퍼 추출)

## Before / After (iOS 26.2 시뮬레이터)

| Before (develop) | After (이 PR) |
| --- | --- |
| <img src="https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-manager-ios/releases/download/verification-assets/TH-1062-before.png" width="360"> | <img src="https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-manager-ios/releases/download/verification-assets/TH-1062-after.png" width="360"> |

- 캡처 방법: 로그인 없이 검증하기 위해 `MyStoreInfoOverviewCell`에 티켓과 동일한 긴 카테고리 3개(mock `BossStoreResponse`)를 바인딩하는 임시 하네스를 각 브랜치 작업트리에만 얹어 촬영했습니다 (하네스 코드는 커밋되지 않음). 스크린샷 원본은 verification-assets 릴리스(Pre-release)에 있습니다.

## 검증
- ✅ Debug 빌드 성공 (3dollar-in-my-pocket-manager-dev)
- ✅ SwiftLint: 수정 파일에 error 없음
- ✅ 시뮬레이터 Before/After 확인 (위 표) — Before에서 칩 오버플로 재현, After에서 2줄 가운데 정렬로 수납
- 카테고리가 1줄에 들어가는 기존 케이스는 줄 분할 결과가 1줄이라 높이·표시 모두 기존과 동일 (회귀 없음)

## 영향 범위
- 가게 정보 탭 overview 카드의 카테고리 표시 및 셀 높이
- **리스크:** 낮음 (1줄 케이스는 기존 동작 유지, 다중 줄일 때만 높이 증가)

## 관련 이슈
- Jira: TH-1062
