### PR TITLE
LookinServer 1.2.8 추가 (Lookin UI 디버깅 툴 연동)

### DIFF
--- a/3dollar-in-my-pocket-manager.xcodeproj/project.pbxproj
+++ b/3dollar-in-my-pocket-manager.xcodeproj/project.pbxproj
@@ -183,6 +183,7 @@
 		6E6B431F285DB9B300AD84A5 /* FAQCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E6B431E285DB9B300AD84A5 /* FAQCollectionViewCell.swift */; };
 		6E6B4321285DBB5900AD84A5 /* FAQHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E6B4320285DBB5900AD84A5 /* FAQHeaderView.swift */; };
 		6E6B82B62CF980E300A5BFAC /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 6E6B82B52CF980E300A5BFAC /* Then */; };
+		6E4C4F4B2E1A000100000001 /* LookinServer in Frameworks */ = {isa = PBXBuildFile; productRef = 6E4C4F4B2E1A000100000003 /* LookinServer */; };
 		6E6C9C69280BD513009AFAE8 /* MyPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E6C9C68280BD513009AFAE8 /* MyPageViewController.swift */; };
 		6E6C9C72280BDC54009AFAE8 /* MyStoreInfoOverviewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E6C9C71280BDC54009AFAE8 /* MyStoreInfoOverviewCell.swift */; };
 		6E6C9C74280BE7B3009AFAE8 /* MyStoreInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E6C9C73280BE7B3009AFAE8 /* MyStoreInfoViewController.swift */; };
@@ -795,6 +796,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6E6B82B62CF980E300A5BFAC /* Then in Frameworks */,
+				6E4C4F4B2E1A000100000001 /* LookinServer in Frameworks */,
 				6EE0CFA127CB567B0027A426 /* KakaoSDKCommon in Frameworks */,
 				6EE0CF9F27CB567B0027A426 /* KakaoSDKAuth in Frameworks */,
 				8E2947D62D0FA7BC00790CFD /* CameraPermission in Frameworks */,
@@ -1864,6 +1866,7 @@
 				6E893CB92C3A65F100357F66 /* netfox */,
 				6E8474BB2C54B3200064DE0A /* CombineCocoa */,
 				6E6B82B52CF980E300A5BFAC /* Then */,
+				6E4C4F4B2E1A000100000003 /* LookinServer */,
 				8E2947D32D0FA79500790CFD /* LocationPermission */,
 				8E2947D52D0FA7BC00790CFD /* CameraPermission */,
 				8E2947D72D0FA7BC00790CFD /* NotificationPermission */,
@@ -1914,6 +1917,7 @@
 				6E893CB82C3A65F100357F66 /* XCRemoteSwiftPackageReference "netfox" */,
 				6E8474BA2C54B3200064DE0A /* XCRemoteSwiftPackageReference "CombineCocoa" */,
 				6E6B82B42CF980E300A5BFAC /* XCRemoteSwiftPackageReference "Then" */,
+				6E4C4F4B2E1A000100000002 /* XCRemoteSwiftPackageReference "LookinServer" */,
 				6EEEDF932E8FB43500AEE6C3 /* XCRemoteSwiftPackageReference "Down" */,
 			);
 			productRefGroup = 6EB94EA127CB208F00609E77 /* Products */;
@@ -2607,6 +2611,14 @@
 				version = 3.0.0;
 			};
 		};
+		6E4C4F4B2E1A000100000002 /* XCRemoteSwiftPackageReference "LookinServer" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/QMUI/LookinServer";
+			requirement = {
+				kind = exactVersion;
+				version = 1.2.8;
+			};
+		};
 		6E6C9C75280BEE26009AFAE8 /* XCRemoteSwiftPackageReference "Kingfisher" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/onevcat/Kingfisher.git";
@@ -2740,6 +2752,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 6E6B82B42CF980E300A5BFAC /* XCRemoteSwiftPackageReference "Then" */;
 			productName = Then;
+		};
+		6E4C4F4B2E1A000100000003 /* LookinServer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6E4C4F4B2E1A000100000002 /* XCRemoteSwiftPackageReference "LookinServer" */;
+			productName = LookinServer;
 		};
 		6E6C9C76280BEE26009AFAE8 /* Kingfisher */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/3dollar-in-my-pocket-manager.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/3dollar-in-my-pocket-manager.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0ffcc88047801bda668e4b0f3cdb066ce4d67645d681a6fb37e327a44ea0c014",
+  "originHash" : "2b70754e70765d5e08f3b248230831ce6cbec0a12a723e48e0f84a5e523b9635",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -134,6 +134,15 @@
       "state" : {
         "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
         "version" : "1.22.5"
+      }
+    },
+    {
+      "identity" : "lookinserver",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/QMUI/LookinServer",
+      "state" : {
+        "revision" : "e553d1b689d147817dc54ad5c28fcff71e860101",
+        "version" : "1.2.8"
       }
     },
     {


### PR DESCRIPTION
## 개요
macOS UI 디버깅 툴 [Lookin](https://github.com/hughkli/Lookin/)을 쓸 수 있도록 iOS 측 라이브러리 [LookinServer](https://github.com/QMUI/LookinServer) 1.2.8을 SPM으로 추가합니다.

## 변경 내용
- `project.pbxproj`: `QMUI/LookinServer` 원격 패키지 추가 (exactVersion 1.2.8 — 다른 패키지들과 동일한 고정 방식)
- `Package.resolved`: LookinServer 핀 추가

## Release 빌드 안전성
LookinServer의 SPM 패키지는 소스 전체가 `SHOULD_COMPILE_LOOKIN_SERVER` 매크로로 감싸져 있고, 이 매크로는 `.when(configuration: .debug)`로 **Debug 구성에서만 정의**됩니다. 이 프로젝트의 빌드 구성 이름이 표준(Debug/Release)이라 가드가 그대로 동작합니다.

**심볼 검증 결과:**
- Debug 빌드: Lookin 심볼 1,607개 포함 (정상 동작)
- Release 빌드: Lookin 클래스/서버 코드 0개 (Swift 호환성 마커 심볼 2개만 존재, 기능 코드 없음) → 앱스토어 제출 안전

## 검증
- ✅ Debug 빌드 성공 (3dollar-in-my-pocket-manager-dev)
- ✅ Release 빌드 성공 (3dollar-in-my-pocket-manager)
- ✅ 시뮬레이터에서 Debug 빌드 실행 시 앱 프로세스가 `localhost:47164`(Lookin 연결 포트) 리슨 확인 — Mac에서 Lookin 앱을 열면 바로 연결됩니다

## 사용 방법
1. Mac에 [Lookin 앱](https://lookin.work/) 설치
2. Debug 빌드로 시뮬레이터/실기기(USB) 실행
3. Lookin 앱에서 자동으로 앱이 목록에 표시됨

## 영향 범위
- Debug 빌드에서만 동작, Release/배포 빌드에는 코드 미포함
- **리스크:** 매우 낮음