### PR TITLE
Xcode Cloud 배포 완료 시 Discord 알림 전송

### DIFF
--- a/ci_scripts/ci_post_xcodebuild.sh
+++ b/ci_scripts/ci_post_xcodebuild.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+
+#  ci_post_xcodebuild.sh
+#  3dollar-in-my-pocket-manager
+#
+#  Xcode Cloud가 빌드/아카이브 직후 실행하는 스크립트.
+#  archive 액션(= TestFlight 업로드) 시 Discord 웹훅으로 배포 정보를 전송한다.
+
+echo "✅ Starting CI post-xcodebuild script..."
+
+# 1) archive 액션일 때만 실행 (test/build 등 다른 액션은 스킵)
+if [ "$CI_XCODEBUILD_ACTION" != "archive" ]; then
+  echo "ℹ️ Not an archive action (action=$CI_XCODEBUILD_ACTION). Skip Discord notify."
+  exit 0
+fi
+
+# 2) 웹훅 URL이 없으면 스킵 (시크릿 미설정이어도 빌드는 깨지 않는다)
+if [ -z "$DISCORD_WEBHOOK_URL" ]; then
+  echo "⚠️ DISCORD_WEBHOOK_URL is not set. Skip Discord notify."
+  exit 0
+fi
+
+# 3) 버전 / 빌드번호 추출
+#    - 버전(마케팅 버전)은 아카이브 Info.plist에서 읽는다.
+#    - 빌드번호는 CI_BUILD_NUMBER를 쓴다. 프로젝트의 CURRENT_PROJECT_VERSION이
+#      "1"로 고정이라 아카이브의 CFBundleVersion은 항상 1이고,
+#      TestFlight에 실제로 올라가는 번호는 Xcode Cloud가 매기는 CI_BUILD_NUMBER다.
+ARCHIVE_PLIST="$CI_ARCHIVE_PATH/Info.plist"
+VERSION="$(/usr/libexec/PlistBuddy -c "Print :ApplicationProperties:CFBundleShortVersionString" "$ARCHIVE_PLIST" 2>/dev/null)"
+[ -z "$VERSION" ] && VERSION="-"
+BUILD="$CI_BUILD_NUMBER"
+[ -z "$BUILD" ] && BUILD="-"
+
+BRANCH="${CI_BRANCH:-${CI_TAG:--}}"
+COMMIT_MSG="$(git -C "$CI_PRIMARY_REPOSITORY_PATH" log -1 --pretty=%B 2>/dev/null)"
+SHORT_SHA="$(printf '%s' "$CI_COMMIT" | cut -c1-7)"
+
+echo "📦 version=$VERSION build=$BUILD branch=$BRANCH commit=$SHORT_SHA"
+
+# 5) python3로 JSON 페이로드 안전하게 생성 (따옴표/줄바꿈/특수문자 이스케이프 처리)
+payload="$(VERSION="$VERSION" BUILD="$BUILD" BRANCH="$BRANCH" \
+  WORKFLOW="$CI_WORKFLOW" SHORT_SHA="$SHORT_SHA" COMMIT_MSG="$COMMIT_MSG" \
+  python3 - <<'PY'
+import os, json
+
+version  = os.environ.get("VERSION") or "-"
+build    = os.environ.get("BUILD") or "-"
+branch   = os.environ.get("BRANCH") or "-"
+workflow = os.environ.get("WORKFLOW") or "-"
+sha      = os.environ.get("SHORT_SHA") or "-"
+# Discord embed description는 4096자 제한이라 넉넉히 자른다
+msg      = (os.environ.get("COMMIT_MSG") or "").strip()[:1500] or "-"
+
+payload = {
+    "username": "Xcode Cloud",
+    "embeds": [{
+        "title": "🧪 [iOS/사장님앱] TestFlight 빌드 업로드",
+        "color": 3066993,
+        "fields": [
+            {"name": "버전",       "value": f"{version} ({build})", "inline": True},
+            {"name": "브랜치",     "value": branch,                 "inline": True},
+            {"name": "워크플로우", "value": workflow,               "inline": True},
+        ],
+        "description": f"**커밋** `{sha}`\n```\n{msg}\n```",
+    }],
+}
+print(json.dumps(payload))
+PY
+)"
+
+# 6) Discord로 전송 (-f: HTTP 4xx/5xx면 실패로 처리해 로그에서 누락 감지)
+if curl -sf -X POST "$DISCORD_WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  -d "$payload"; then
+  echo "✅ Discord notify sent."
+else
+  echo "❌ Discord notify failed."
+fi
+
+# 알림 실패가 빌드 전체를 깨뜨리지 않도록 항상 0으로 종료
+exit 0


### PR DESCRIPTION
## 개요
유저앱과 동일하게, Xcode Cloud에서 아카이브(TestFlight 업로드)가 완료되면 Discord로 배포 알림을 전송합니다.

## 변경 내용
- `ci_scripts/ci_post_xcodebuild.sh` 추가 — 유저앱(3dollars-in-my-pocket-ios)의 스크립트와 동일 구조:
  - `archive` 액션에서만 동작 (build/test는 스킵)
  - `DISCORD_WEBHOOK_URL` 미설정 시 조용히 스킵 (빌드에 영향 없음)
  - 버전은 아카이브 Info.plist, 빌드번호는 `CI_BUILD_NUMBER` (프로젝트가 `CURRENT_PROJECT_VERSION=1` 고정이라 유저앱과 동일한 방식)
  - embed에 버전/브랜치/워크플로우/커밋 표시, 제목은 `[iOS/사장님앱]`으로 구분 (색상도 유저앱과 다른 초록 계열)
  - 알림 실패 시에도 `exit 0` — 배포 자체를 깨뜨리지 않음

## 검증
- ✅ 로컬 드라이런: mock 아카이브 plist + 로컬 mock 웹훅 서버로 시나리오 테스트
  - `build` 액션 → 스킵 확인
  - `archive` 액션 → `버전 1.13.1 (57)`, 브랜치/워크플로우/커밋 포함 embed 정상 전송 확인
  - 웹훅 URL 미설정 → 스킵 확인

## ⚠️ 머지 후 필요한 설정 (1회)
App Store Connect → Xcode Cloud → **3dollar-in-my-pocket-manager** 프로덕트 → "Dev앱 배포" 워크플로우 편집 → Environment → Environment Variables에
`DISCORD_WEBHOOK_URL` = (유저앱 워크플로우와 동일한 웹훅 URL, **Secret 체크**)
를 추가해야 알림이 전송됩니다. 환경변수는 ASC API로 설정할 수 없어 수동 등록이 필요합니다. 실배포 워크플로우에도 알림을 원하면 같은 변수를 추가하면 됩니다.

## 영향 범위
- CI 스크립트만 추가 — 앱 코드/빌드 결과물 변화 없음
- **리스크:** 매우 낮음