### PR TITLE
TH-1215 : 리뷰 상세 진입 후 뒤로가기 시 네비게이션 바가 빈 영역으로 남는 문제 수정

### DIFF
--- a/3dollar-in-my-pocket-manager/domains/MyStore/Statistics/ReviewDetail/ReviewDetailViewController.swift
+++ b/3dollar-in-my-pocket-manager/domains/MyStore/Statistics/ReviewDetail/ReviewDetailViewController.swift
@@ -48,10 +48,22 @@ final class ReviewDetailViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         setupUI()
         setupKeyboardEvent()
         viewModel.input.firstLoad.send(())
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        navigationController?.isNavigationBarHidden = false
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        navigationController?.isNavigationBarHidden = true
     }
     
     private func setupUI() {


### PR DESCRIPTION
## 원인
메인 탭 계층은 시스템 네비게이션 바를 숨긴 상태(`MainTabController` / `SceneDelegate.goToMain()`에서 `isNavigationBarHidden = true`)로 동작하는데, 리뷰 상세 화면이 `setupUI()`에서 `addNavigationBar()`로 시스템 네비게이션 바를 노출(`isNavigationBarHidden = false`)시킨 뒤 **pop 시 다시 숨기는 처리가 없어** 리뷰통계 화면 위에 빈 네비게이션 바 영역이 남습니다.

**문제 코드:** `ReviewDetailViewController.swift` — `setupUI()`의 `addNavigationBar()` 호출 (line 59) 이후 복원 로직 부재

같은 위치에서 push되는 형제 화면들(`FeedbackDetailViewController`, `ReivewListViewController`)은 모두 `viewWillAppear`/`viewWillDisappear`에서 네비게이션 바 노출 상태를 토글하고 있으나 `ReviewDetailViewController`만 누락되어 있었습니다.

## 재현 경로
1. 사장님앱 → 리뷰통계 탭 진입
2. 리뷰 항목 탭 → 리뷰 상세 진입 (시스템 네비게이션 바 노출)
3. 뒤로가기
4. **실제:** 리뷰통계 화면 상단에 빈 네비게이션 바 영역이 남아 콘텐츠가 아래로 밀림 / **기대:** 진입 전과 동일한 레이아웃

## 수정 방향
`FeedbackDetailViewController`와 동일한 패턴으로 `viewWillAppear`(노출)/`viewWillDisappear`(숨김) 오버라이드를 추가했습니다.

**수정 내용:**
- `ReviewDetailViewController.swift`: `viewWillAppear`/`viewWillDisappear`에서 `navigationController?.isNavigationBarHidden` 토글 추가

## 검증
- ✅ Debug 빌드 성공 (3dollar-in-my-pocket-manager-dev)
- ✅ SwiftLint — 추가된 라인 위반 없음 (기존 warning만 존재)
- ✅ 시뮬레이터 Before/After 검증 (iPhone 17 Pro, iOS 26.2, mock repository QA 하네스로 리뷰통계→리뷰상세→뒤로가기 재현)

### 시뮬레이터 검증 스크린샷 (리뷰 상세 진입 후 뒤로가기 직후)
| Before (develop) | After (본 브랜치) |
|:---:|:---:|
| <img src="https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-manager-ios/releases/download/verification-assets/TH-1215-before.png" width="320"> | <img src="https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-manager-ios/releases/download/verification-assets/TH-1215-after.png" width="320"> |

Before는 상단에 빈 네비게이션 바 영역이 남아 콘텐츠가 아래로 밀리고, After는 [진입 전 원본 레이아웃](https://github.com/3dollar-in-my-pocket/3dollars-in-my-pocket-manager-ios/releases/download/verification-assets/TH-1215-baseline.png)과 동일하게 복원됩니다.

## 영향 범위
- 리뷰통계 → 리뷰 상세 (`StatisticsViewController` → `ReviewDetailViewController`)
- 리뷰 전체 보기 → 리뷰 상세 경로는 `ReviewListViewController`가 자체적으로 `viewWillAppear`에서 노출 처리하므로 동작 변화 없음 (pop 시 disappear(숨김) → appear(노출) 순서로 기존과 동일)
- **리스크:** 매우 낮음 (기존 형제 화면들과 동일한 검증된 패턴, 1파일 수정)

## 관련 이슈
- Jira: TH-1215